### PR TITLE
[UES-900] Difficult to delete characters in the beginning of a URL in a dashboard

### DIFF
--- a/apps/portal/js/create.js
+++ b/apps/portal/js/create.js
@@ -154,8 +154,8 @@ $(function () {
             hideInlineError($(this), $("#id-error"));
         }
 
-        // If the key released is not a generic key (E.g - arrow keys, backspace, delete), update the URL field
-        if(e.which == "number" && e.which > 0)
+        // If the key released is not a generic key other than space (E.g - arrow keys, backspace, delete), update the URL field
+        if((e.which == "number" && e.which > 0) || e.keyCode == 0 || e.keyCode == 32)
             $(this).val(generateUrl($(this).val()));
     });
 

--- a/apps/portal/js/create.js
+++ b/apps/portal/js/create.js
@@ -148,12 +148,15 @@ $(function () {
     // Bind event handlers for dashboard ID field
     $('#ues-dashboard-id').on("keypress", function (e) {
         return sanitizeOnKeyPress(this, e, /[^a-z0-9-\s]/gim);
-    }).on('keyup', function () {
+    }).on('keyup', function (e) {
         overridden = overridden || true;
         if ($(this).val()) {
             hideInlineError($(this), $("#id-error"));
         }
-        $(this).val(generateUrl($(this).val()));
+
+        // If the key released is not a generic key (E.g - arrow keys, backspace, delete), update the URL field
+        if(e.which == "number" && e.which > 0)
+            $(this).val(generateUrl($(this).val()));
     });
 
     // Bind event handlers for dashboard description field

--- a/apps/portal/js/create.js
+++ b/apps/portal/js/create.js
@@ -155,7 +155,7 @@ $(function () {
         }
 
         // If the key released is not a generic key other than space (E.g - arrow keys, backspace, delete), update the URL field
-        if((e.which == "number" && e.which > 0) || e.keyCode == 0 || e.keyCode == 32)
+        if ((e.which == "number" && e.which > 0) || e.keyCode == 0 || e.keyCode == 32)
             $(this).val(generateUrl($(this).val()));
     });
 


### PR DESCRIPTION
This issue is due to URL text box is being updated for every key released to ensure the URL is within maximum of 100 characters. In that case, when a backspace/delete character or other common keys are pressed, the URL need not be updated as they will have no effect in increase of URL length. This PR fixes that issue.

Public JIra - [https://wso2.org/jira/browse/UES-900]