### PR TITLE
Adding feature to access the secured backend APIs at gadgets level

### DIFF
--- a/apps/portal/configs/designer.json
+++ b/apps/portal/configs/designer.json
@@ -8,15 +8,35 @@
       "sso": {
         "attributes": {
           "issuer": "portal",
-          "identityProviderURL": "https://localhost:9443/samlsso",
+          "identityProviderURL": "%https.ip%/samlsso",
           "responseSigningEnabled": "false",
-          "acs": "https://localhost:9444/portal/acs",
+          "acs": "%https.ip%/portal/acs",
           "identityAlias": "wso2carbon",
           "useTenantKey": false
         }
       },
       "basic": {
         "attributes": {}
+      }
+    }
+  },
+  "authorization": {
+    "activeMethod": "",
+    "methods": {
+      "oauth": {
+        "attributes": {
+          "idPServer": "%https.ip%/oauth2/token",
+          "dynamicClientProperties": {
+            "callbackUrl": "%https.ip%/portal",
+            "clientName": "portal",
+            "owner": "admin",
+            "applicationType": "JaggeryApp",
+            "grantType": "password refresh_token urn:ietf:params:oauth:grant-type:saml2-bearer",
+            "saasApp": false,
+            "dynamicClientRegistrationEndPoint": "%https.ip%/dynamic-client-web/register/",
+            "tokenScope": "Production"
+          }
+        }
       }
     }
   },

--- a/apps/portal/configs/designer.json
+++ b/apps/portal/configs/designer.json
@@ -8,9 +8,9 @@
       "sso": {
         "attributes": {
           "issuer": "portal",
-          "identityProviderURL": "%https.ip%/samlsso",
+          "identityProviderURL": "https://localhost:9443/samlsso",
           "responseSigningEnabled": "false",
-          "acs": "%https.ip%/portal/acs",
+          "acs": "https://localhost:9444/portal/acs",
           "identityAlias": "wso2carbon",
           "useTenantKey": false
         }

--- a/apps/portal/controllers/acs.jag
+++ b/apps/portal/controllers/acs.jag
@@ -18,15 +18,18 @@
  *
  */
 (function () {
-    var log = new Log();
+    var log = new Log("/controllers/acs.jag");
     var configs = require('/configs/portal.js').config();
     var samlResponse = request.getParameter('SAMLResponse');
     var sessionId = session.getId();
     var samlRequest = request.getParameter('SAMLRequest');
+    var dashboards = require('/modules/dashboards.js');
     //see https://wso2.org/jira/browse/IDENTITY-3454
     var relayState = decodeURIComponent(request.getParameter('RelayState'));
     var attr = configs.authentication.methods.sso.attributes;
     var sso = require('sso');
+    var tokenUtil = require("/modules/tokenUtil.js").tokenUtil;
+    var constants = require("/controllers/constants/constants.js");
     var samlRespObj;
     var CarbonUtils = Packages.org.wso2.carbon.utils.CarbonUtils;
     var keyStorePassword = CarbonUtils.getServerConfiguration().getFirstProperty("Security.TrustStore.Password");
@@ -89,10 +92,23 @@
                         user.roles = um.getRoleListOfUser(user.username);
                         session.put('user', user);
                         session.put("samlResponse", samlResponse);
-                        var saml2Cookie = require('/modules/saml-to-cookie.js');
-                        var authToken = saml2Cookie.exchangeSAMLTokenForCookie(samlResponse);
-                        session.put('authToken', authToken);
-                        response.sendRedirect(relayState);
+                        var idPServer = tokenUtil.getIdPServerURL();
+                        if (tokenUtil.checkOAuthEnabled() && idPServer) {
+                            var properties = {samlToken: sessionObj.samlToken, user: username};
+                            tokenUtil.setupAccessTokenPair(constants.GRANT_TYPE_SAML, properties, idPServer,
+                                    function (status) {
+                                        if (!status) {
+                                            log.error("Error while setting up access token and refresh token");
+                                        }
+                                    });
+                            response.sendRedirect(relayState);
+                            return;
+                        } else {
+                            var saml2Cookie = require('/modules/saml-to-cookie.js');
+                            var authToken = saml2Cookie.exchangeSAMLTokenForCookie(samlResponse);
+                            session.put('authToken', authToken);
+                            response.sendRedirect(relayState);
+                        }
                     }
                 }
             }

--- a/apps/portal/controllers/apis/HTTPClient.jag
+++ b/apps/portal/controllers/apis/HTTPClient.jag
@@ -1,0 +1,139 @@
+<%
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This HTTPClient contains the wrappers for back end http calls.
+ */
+(function () {
+
+    var log = new Log("/controllers/apis/HTTPClient.jag");
+    var carbon = require('carbon');
+    var configs = require('/configs/designer.json');
+    var constants = require("/controllers/constants/constants.js");
+    var RESTClientInvoker = require("/controllers/apis/RESTClientInvoker.jag").RESTClientInvoker;
+    var utils = require('/modules/utils.js');
+    var tokenUtil = require("/modules/tokenUtil.js").tokenUtil;
+    var uri = request.getRequestURI();
+    var uriMatcher = new URIMatcher(String(uri));
+    var method = request.getMethod();
+
+    tokenUtil.isUserAuthorized(function (status) {
+        if (!status) {
+            response.status = constants.HTTP_USER_NOT_AUTHENTICATED;
+            response.content = sendErrorMessage("You have not login to the wso2 dashboard server yet");
+            return;
+        }
+    });
+
+    if (uriMatcher.match("/HTTPClient") && method === constants.HTTP_POST) {
+        method = request.getContent().actionMethod;
+        var targetURL = request.getContent().actionUrl;
+        var payload = request.getContent().actionPayload;
+        var contentType = request.getHeader(constants.CONTENT_TYPE_IDENTIFIER);
+        response.contentType = contentType;
+        var acceptType = request.getHeader(constants.ACCEPT_IDENTIFIER);
+        if (method == undefined && targetURL == undefined && request.getContent()) {
+            method = parse(request.getContent()).actionMethod;
+            targetURL = parse(request.getContent()).actionUrl;
+            payload = parse(request.getContent()).actionPayload;
+        }
+        if (method == undefined && targetURL == undefined) {
+            response.status = constants.HTTP_BAD_REQUEST;
+            response.content = sendErrorMessage("Please specify target URL and HTTP Verb which needs to be called");
+            return;
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("method: " + method);
+                log.debug("targetURL: " + targetURL);
+                log.debug("payload: " + stringify(payload));
+            }
+            try {
+                switch (method) {
+                    case constants.HTTP_GET:
+                        RESTClientInvoker.HTTPClient.GET(
+                                targetURL, function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                contentType,
+                                acceptType);
+                        break;
+                    case constants.HTTP_POST:
+                        RESTClientInvoker.HTTPClient.POST(
+                                targetURL, payload, function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                contentType,
+                                acceptType);
+                        break;
+                    case constants.HTTP_PUT:
+                        RESTClientInvoker.HTTPClient.PUT(
+                                targetURL, payload, function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                contentType,
+                                acceptType);
+                        break;
+                    case constants.HTTP_DELETE:
+                        RESTClientInvoker.HTTPClient.DELETE(
+                                targetURL, function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                function (responsePayload) {
+                                    response.status = responsePayload.status;
+                                    response.content = responsePayload.responseText;
+                                },
+                                contentType,
+                                acceptType);
+                        break;
+                }
+            } catch (e) {
+                log.error("Exception occurred while accessing back end service" + e);
+                response.status = constants.HTTP_INTERNAL_ERROR;
+                response.content = sendErrorMessage("Exception occurred while accessing back end service");
+                return;
+            }
+        }
+    } else {
+        response.status = constants.HTTP_BAD_REQUEST;
+        response.content = sendErrorMessage("HTTP Verb : " + method + " doesn't support for this operation");
+        return;
+    }
+
+    function sendErrorMessage(message) {
+        return {"message": message};
+    }
+
+}());
+%>

--- a/apps/portal/controllers/apis/RESTClientInvoker.jag
+++ b/apps/portal/controllers/apis/RESTClientInvoker.jag
@@ -55,7 +55,10 @@ var RESTClientInvoker = function () {
                     }
                 });
             } else {
-                log.debug("OAuth hasn't been enabled yet. This will cause problems if backed is secured with OAuth");
+                if (log.isDebugEnabled()) {
+                    log.debug("OAuth hasn't been enabled yet. This will cause problems if backed is secured with" +
+                            "OAuth");
+                }
             }
             xmlHttpRequest.send(payload);
             if ((xmlHttpRequest.status >= 200 && xmlHttpRequest.status < 300) || xmlHttpRequest.status == 302) {
@@ -188,7 +191,10 @@ var RESTClientInvoker = function () {
                     }
                 });
             } else {
-                log.debug("OAuth is hasn't been enabled yet. This will cause problems if backed is secured with OAuth");
+                if (log.isDebugEnabled()) {
+                    log.debug("OAuth is hasn't been enabled yet. This will cause problems if backed is secured" +
+                            "with OAuth");
+                }
             }
             if (payload !== null) {
                 var StringRequestEntity = Packages.org.apache.commons.httpclient.methods.StringRequestEntity;

--- a/apps/portal/controllers/apis/RESTClientInvoker.jag
+++ b/apps/portal/controllers/apis/RESTClientInvoker.jag
@@ -1,0 +1,310 @@
+<%
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This RESTClientInvoker is the where actual backed call is made. It may be a pure HTTP request or XMLHTTP request.
+ */
+var RESTClientInvoker = function () {
+    var log = new Log("/controllers/api/RESTClientInvoker.jag");
+    var publicXMLHTTPInvokers = {};
+    var publicHTTPInvokers = {};
+    var privateMethods = {};
+    var TOKEN_EXPIRED = "Access token expired";
+    var TOKEN_INVALID = "Invalid input. Access token validation failed";
+    var constants = require("/controllers/constants/constants.js");
+    var tokenUtil = require("/modules/tokenUtil.js").tokenUtil;
+
+    /**
+     * This method add OAuth authentication header to outgoing XML HTTP Requests if OAuth authentication is enabled.
+     * @param method             HTTP request type.
+     * @param url                target url.
+     * @param payload            payload/data which need to be send.
+     * @param successCallback    a function to be called if the respond if successful.
+     * @param errorCallback      a function to be called if en error is reserved.
+     * @param contentType        requested endpoint should be supported this media type
+     * @param acceptType         this is the media type which is accepted
+     */
+    privateMethods.XMLHTTPRequest = function (method, url, payload, successCallback, errorCallback, contentType,
+                                              acceptType) {
+        var execute = function (count) {
+            var xmlHttpRequest = new XMLHttpRequest();
+            xmlHttpRequest.open(method, url);
+            xmlHttpRequest.setRequestHeader(constants.CONTENT_TYPE_IDENTIFIER, contentType);
+            xmlHttpRequest.setRequestHeader(constants.ACCEPT_IDENTIFIER, acceptType);
+            if (tokenUtil.checkOAuthEnabled()) {
+                tokenUtil.setAccessToken(xmlHttpRequest, function (modifiedXHR) {
+                    xmlHttpRequest = modifiedXHR;
+                    if (xmlHttpRequest === null) {
+                        log.error("Your login session is expired. Please login again");
+                    }
+                });
+            } else {
+                log.debug("OAuth hasn't been enabled yet. This will cause problems if backed is secured with OAuth");
+            }
+            xmlHttpRequest.send(payload);
+            if ((xmlHttpRequest.status >= 200 && xmlHttpRequest.status < 300) || xmlHttpRequest.status == 302) {
+                return successCallback(xmlHttpRequest);
+            } else if (xmlHttpRequest.status == 401 && (xmlHttpRequest.responseText == TOKEN_EXPIRED ||
+                    xmlHttpRequest.responseText == TOKEN_INVALID ) && count < 3) {
+                tokenUtil.refreshAccessToken(function (status) {
+                    if (status) {
+                        return execute(count + 1);
+                    } else {
+                        return errorCallback(xmlHttpRequest);
+                    }
+                });
+            } else {
+                return errorCallback(xmlHttpRequest);
+            }
+        };
+        return execute(0);
+    }
+
+    /**
+     * This method invokes return XMLHTTPRequest for get calls
+     * @param url              target url.
+     * @param successCallback  a function to be called if the respond if successful.
+     * @param errorCallback    a function to be called if en error is reserved.
+     * @param contentType        requested endpoint should be supported this media type
+     * @param acceptType         this is the media type which is accepted
+     */
+    publicXMLHTTPInvokers.GET = function (url, successCallback, errorCallback, contentType, acceptType) {
+        var payload = null;
+        return privateMethods.XMLHTTPRequest(constants.HTTP_GET, url, payload, successCallback, errorCallback,
+                contentType, acceptType);
+    };
+
+    /**
+     * This method invokes return XMLHTTPRequest for post calls
+     * @param url              target url.
+     * @param payload          payload/data which need to be send.
+     * @param successCallback  a function to be called if the respond if successful.
+     * @param errorCallback    a function to be called if en error is reserved.
+     * @param contentType        requested endpoint should be supported this media type
+     * @param acceptType         this is the media type which is accepted
+     */
+    publicXMLHTTPInvokers.POST = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        return privateMethods.XMLHTTPRequest(constants.HTTP_POST, url, payload, successCallback, errorCallback,
+                contentType, acceptType);
+    };
+
+    /**
+     * This method invokes return XMLHTTPRequest for put calls
+     * @param url               target url.
+     * @param payload           payload/data which need to be send.
+     * @param successCallback   a function to be called if the respond if successful.
+     * @param errorCallback     a function to be called if en error is reserved.
+     * @param contentType        requested endpoint should be supported this media type
+     * @param acceptType         this is the media type which is accepted
+     */
+    publicXMLHTTPInvokers.PUT = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        return privateMethods.XMLHTTPRequest(constants.HTTP_PUT, url, payload, successCallback, errorCallback,
+                contentType, acceptType);
+    };
+
+    /**
+     * This method invokes return XMLHTTPRequest for delete calls
+     * @param url                target url.
+     * @param successCallback    a function to be called if the respond if successful.
+     * @param errorCallback      a function to be called if en error is reserved.
+     * @param contentType        requested endpoint should be supported this media type
+     * @param acceptType         this is the media type which is accepted
+     */
+    publicXMLHTTPInvokers.DELETE = function (url, successCallback, errorCallback, contentType, acceptType) {
+        var payload = null;
+        return privateMethods.XMLHTTPRequest(constants.HTTP_DELETE, url, payload, successCallback, errorCallback,
+                contentType, acceptType);
+    };
+
+    /**
+     * This method add Oauth authentication header to outgoing HTTPClient Requests if Oauth authentication is enabled.
+     * @param method          HTTP request type.
+     * @param url             target url.
+     * @param payload         payload/data which need to be send.
+     * @param successCallback a function to be called if the respond if successful.
+     * @param errorCallback   a function to be called if en error is reserved.
+     * @param contentType     requested endpoint should be supported this media type
+     * @param acceptType      this is the media type which is accepted
+     */
+    privateMethods.HTTPRequest = function (method, url, payload, successCallback, errorCallback, contentType,
+                                           acceptType) {
+        var HttpClient = Packages.org.apache.commons.httpclient.HttpClient;
+        var httpMethodObject;
+        switch (method) {
+            case constants.HTTP_POST:
+                var PostMethod = Packages.org.apache.commons.httpclient.methods.PostMethod;
+                httpMethodObject = new PostMethod(url);
+                break;
+            case constants.HTTP_PUT:
+                var PutMethod = Packages.org.apache.commons.httpclient.methods.PutMethod;
+                httpMethodObject = new PutMethod(url);
+                break;
+            case constants.HTTP_GET:
+                var GetMethod = Packages.org.apache.commons.httpclient.methods.GetMethod;
+                httpMethodObject = new GetMethod(url);
+                break;
+            case constants.HTTP_DELETE:
+                var DeleteMethod = Packages.org.apache.commons.httpclient.methods.DeleteMethod;
+                httpMethodObject = new DeleteMethod(url);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid HTTP request type: " + method);
+        }
+        var execute = function (count) {
+            var Header = Packages.org.apache.commons.httpclient.Header;
+            var header = new Header();
+            header.setName(constants.CONTENT_TYPE_IDENTIFIER);
+            header.setValue(contentType);
+            httpMethodObject.addRequestHeader(header);
+            header = new Header();
+            header.setName(constants.ACCEPT_IDENTIFIER);
+            header.setValue(acceptType);
+            httpMethodObject.addRequestHeader(header);
+            if (tokenUtil.checkOAuthEnabled()) {
+                tokenUtil.getAccessToken(function (accessToken) {
+                    if (accessToken !== null) {
+                        header = new Header();
+                        header.setName(constants.AUTHORIZATION_HEADER);
+                        header.setValue(constants.BEARER_PREFIX + accessToken);
+                        httpMethodObject.addRequestHeader(header);
+                    } else {
+                        log.error("Your login session is expired. Please login again");
+                    }
+                });
+            } else {
+                log.debug("OAuth is hasn't been enabled yet. This will cause problems if backed is secured with OAuth");
+            }
+            if (payload !== null) {
+                var StringRequestEntity = Packages.org.apache.commons.httpclient.methods.StringRequestEntity;
+                var stringRequestEntity = new StringRequestEntity(stringify(payload));
+                httpMethodObject.setRequestEntity(stringRequestEntity);
+            }
+
+            var client = new HttpClient();
+            var responsePayload = {};
+            try {
+                client.executeMethod(httpMethodObject);
+                var status = httpMethodObject.getStatusCode();
+                responsePayload.status = status;
+                responsePayload.responseText = httpMethodObject.getResponseBodyAsString();
+                if (responsePayload.responseText == "") {
+                    responsePayload.responseText = sendMessage("response is empty");
+                }
+                if (status >= 200 && status < 400) {
+                    var responseContentTypeHeader = httpMethodObject.getResponseHeader(constants.CONTENT_TYPE_IDENTIFIER);
+                    if (responseContentTypeHeader && responseContentTypeHeader.getValue() == constants.APPLICATION_ZIP) {
+                        responsePayload.responseText = httpMethodObject.getResponseBodyAsStream();
+                        responsePayload.header = httpMethodObject.getResponseHeaders();
+                    }
+                    successCallback(responsePayload);
+
+                } else if (status == 401 && (responsePayload.responseText == TOKEN_EXPIRED ||
+                        responsePayload.responseText == TOKEN_INVALID ) && count < 3) {
+                    tokenUtil.refreshAccessToken(function (status) {
+                        if (status) {
+                            return execute(count + 1);
+                        } else {
+                            return errorCallback(responsePayload);
+                        }
+                    });
+                } else {
+                    errorCallback(responsePayload);
+                }
+            } catch (e) {
+                var errorMessage = "Error while sending http request to backend, " + e;
+                throw errorMessage;
+                responsePayload.responseText = errorMessage;
+                errorCallback(responsePayload);
+            } finally {
+                httpMethodObject.releaseConnection();
+            }
+        }
+        return execute(0);
+    };
+
+    /**
+     * This method invokes return HTTPRequest for get calls
+     * @param url             target url.
+     * @param successCallback a function to be called if the respond if successful.
+     * @param errorCallback   a function to be called if en error is reserved.
+     * @param contentType        requested endpoint should be supported this media type
+     * @param acceptType         this is the media type which is accepted
+     */
+    publicHTTPInvokers.GET = function (url, successCallback, errorCallback, contentType, acceptType) {
+        return privateMethods.HTTPRequest(constants.HTTP_GET, url, null, successCallback, errorCallback, contentType,
+                acceptType);
+    };
+
+    /**
+     * This method invokes return HTTPRequest for post calls
+     * @param url             target url.
+     * @param payload         payload/data which need to be send.
+     * @param successCallback a function to be called if the respond if successful.
+     * @param errorCallback   a function to be called if en error is reserved.
+     * @param contentType     requested endpoint should be supported this media type
+     * @param acceptType      this is the media type which is accepted
+     */
+    publicHTTPInvokers.POST = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        return privateMethods
+                .HTTPRequest(constants.HTTP_POST, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+
+    /**
+     * This method invokes return HTTPRequest for put calls
+     * @param url             target url.
+     * @param payload         payload/data which need to be send.
+     * @param successCallback a function to be called if the respond if successful.
+     * @param errorCallback   a function to be called if en error is reserved.
+     * @param contentType     requested endpoint should be supported this media type
+     * @param acceptType      this is the media type which is accepted
+     */
+    publicHTTPInvokers.PUT = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        return privateMethods
+                .HTTPRequest(constants.HTTP_PUT, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+
+    /**
+     * This method invokes return HTTPRequest for delete calls
+     * @param url              target url.
+     * @param successCallback  a function to be called if the respond if successful.
+     * @param errorCallback    a function to be called if en error is reserved.
+     * @param contentType        requested endpoint should be supported this media type
+     * @param acceptType         this is the media type which is accepted
+     */
+    publicHTTPInvokers.DELETE = function (url, successCallback, errorCallback, contentType, acceptType) {
+        return privateMethods
+                .HTTPRequest(constants.HTTP_DELETE, url, null, successCallback, errorCallback, contentType, acceptType);
+    };
+
+    /**
+     * Send error message when something went wrong
+     * @param message   error message
+     * @returns {{message: *}}
+     */
+    function sendMessage(message) {
+        return {"message": message};
+    }
+
+    var publicInvokers = {};
+    publicInvokers.XMLHTTPClient = publicXMLHTTPInvokers;
+    publicInvokers.HTTPClient = publicHTTPInvokers;
+    return publicInvokers;
+
+}();
+%>

--- a/apps/portal/controllers/apis/XMLHTTPClient.jag
+++ b/apps/portal/controllers/apis/XMLHTTPClient.jag
@@ -1,0 +1,133 @@
+<%
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * This XMLHTTPClient contains the wrappers for back end xmlhttp calls.
+ */
+(function () {
+
+    var log = new Log("/controllers/apis/XMLHTTPClient.jag");
+    var carbon = require('carbon');
+    var configs = require('/configs/designer.json');
+    var constants = require("/controllers/constants/constants.js");
+    var RESTClientInvoker = require("/controllers/apis/RESTClientInvoker.jag").RESTClientInvoker;
+    var utils = require('/modules/utils.js');
+    var uri = request.getRequestURI();
+    var uriMatcher = new URIMatcher(String(uri));
+    var method = request.getMethod();
+    var tokenUtil = require("/modules/tokenUtil.js").tokenUtil;
+
+    tokenUtil.isUserAuthorized(function(status){
+        if(!status){
+            response.status = constants.HTTP_USER_NOT_AUTHENTICATED;
+            response.content = sendErrorMessage("You have not login to the wso2 dashboard server yet")
+        }else{
+            if (uriMatcher.match("/XMLHTTPClient") && method === constants.HTTP_POST) {
+                method = request.getContent().actionMethod;
+                var targetURL = request.getContent().actionUrl;
+                var payload = request.getContent().actionPayload;
+                var contentType = request.getHeader(constants.CONTENT_TYPE_IDENTIFIER);
+                var acceptType = request.getHeader(constants.ACCEPT_IDENTIFIER);
+                response.contentType = contentType;
+                if (method == undefined && targetURL == undefined && request.getContent()) {
+                    method = parse(request.getContent()).actionMethod;
+                    targetURL =parse(request.getContent()).actionUrl;
+                    payload = parse(request.getContent()).actionPayload;
+                }
+                if (method == undefined && targetURL == undefined) {
+                    response.status = constants.HTTP_BAD_REQUEST;
+                    response.content = sendErrorMessage("Please specify target URL and HTTP Verb which needs to be called");
+                    return;
+                }else{
+                    if (log.isDebugEnabled()) {
+                        log.debug("method: " + method);
+                        log.debug("targetURL: " + targetURL);
+                        log.debug("payload: " + stringify(payload));
+                    }
+                    try {
+                        switch (method) {
+                            case constants.HTTP_GET:
+                                RESTClientInvoker.XMLHTTPClient.GET(
+                                        targetURL, function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        contentType,acceptType);
+                                break;
+                            case constants.HTTP_POST:
+                                RESTClientInvoker.XMLHTTPClient.POST(
+                                        targetURL, payload, function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        contentType,acceptType);
+                                break;
+                            case constants.HTTP_PUT:
+                                RESTClientInvoker.XMLHTTPClient.PUT(
+                                        targetURL, payload, function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        contentType,acceptType);
+                                break;
+                            case constants.HTTP_DELETE:
+                                RESTClientInvoker.XMLHTTPClient.DELETE(
+                                        targetURL, function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        function (responsePayload) {
+                                            response.status = responsePayload.status;
+                                            response.content = responsePayload.responseText;
+                                        },
+                                        contentType,acceptType);
+                                break;
+                        }
+                    } catch (e) {
+                        log.error("Exception occurred while accessing back end service"+ e);
+                        response.status = constants.HTTP_INTERNAL_ERROR;
+                        response.content = sendErrorMessage("Exception occurred while accessing back end service");
+                        return;
+                    }
+                }
+            }else{
+                response.status = constants.HTTP_BAD_REQUEST;
+                response.content = sendErrorMessage("HTTP Verb : " +method+ " doesn't support for this operation" );
+                return;
+            }
+        }
+    });
+
+    function sendErrorMessage(message){
+        return {"message": message};
+    }
+
+}());
+%>

--- a/apps/portal/controllers/constants/constants.js
+++ b/apps/portal/controllers/constants/constants.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+var CONTENT_TYPE_IDENTIFIER = "Content-Type";
+var APPLICATION_JSON = "application/json";
+var APPLICATION_X_WWW_FOR_URLENCODED = "application/x-www-form-urlencoded";
+var APPLICATION_ZIP = "application/zip";
+
+var ACCESS_TOKEN_PAIR_IDENTIFIER = "accessTokenPair";
+var ENCODED_CLIENT_KEYS_IDENTIFIER = "encodedClientKey";
+var AUTHORIZATION_HEADER = "Authorization";
+var SCOPE_PRODUCTION = "PRODUCTION"
+var BEARER_PREFIX = "Bearer ";
+var BASIC_PREFIX = "Basic ";
+var ACCEPT_IDENTIFIER = "Accept";
+var AUTHENTICATION_TYPE_SSO = "sso";
+var AUTHENTICATION_TYPE_BASIC = "basic";
+var AUTHORIZATION_TYPE_OAUTH = "oauth";
+var LOGIN_MESSAGE = "true";
+var GRANT_TYPE_PASSWORD = "password";
+var GRANT_TYPE_SAML = "saml";
+
+var HTTP_GET = "GET";
+var HTTP_POST = "POST";
+var HTTP_PUT = "PUT";
+var HTTP_DELETE = "DELETE";
+
+var HTTP_CONFLICT = 409;
+var HTTP_BAD_REQUEST = 400;
+var HTTP_CREATED = 201;
+var HTTP_UNAUTHORIZED = 401;
+var HTTP_USER_NOT_AUTHENTICATED = 403;
+var HTTP_INTERNAL_ERROR = 500;
+var HTTP_ACCEPTED = 200;

--- a/apps/portal/controllers/login.jag
+++ b/apps/portal/controllers/login.jag
@@ -1,6 +1,6 @@
 <%
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,9 @@ var dest;
     var log = new Log();
     var method = request.getMethod();
     var configs = require('/configs/portal.js').config();
+    var tokenUtil = require("/modules/tokenUtil.js").tokenUtil;
+    var constants = require("/controllers/constants/constants.js");
+    var dashboards = require('/modules/dashboards.js');
     dest = request.getParameter('destination');
 
     if (method === 'POST') {
@@ -34,20 +37,20 @@ var dest;
             // Check whether the dest. URL starts with either http:// or https://. If so remove the authority and get
             // the rest of the URL.
             if (/^https?:\/\//i.test(dest)) {
-                var url = new Packages.java.net.URL(dest), 
-                    authority = url.getAuthority();            
+                var url = new Packages.java.net.URL(dest),
+                        authority = url.getAuthority();
                 dest = dest.substring(dest.indexOf(authority) + authority.length());
             }
             // Check whether the dest. URL starts with '/'. If not prepend the '/'.
-            if (! /^\//i.test(dest)) {
+            if (!/^\//i.test(dest)) {
                 dest = '/' + dest;
             }
             // Check whether the dest. URL starts with '/portal'. if not set the url to '/portal'.
-            if (! /^\/portal/i.test(dest)) {
+            if (!/^\/portal/i.test(dest)) {
                 dest = '/portal';
             }
         }
-        
+
         carbon = require('carbon');
         username = request.getParameter('username');
         user = carbon.server.tenantUser(username);
@@ -55,11 +58,20 @@ var dest;
             usr = require('/modules/user.js');
             password = request.getParameter('password');
             if (usr.login(username, password)) {
+                session.put("Loged", "true");
                 //authorize the backend API too
                 var api = require('/modules/api.js');
                 var authToken = api.authenticate(username, password);
+                var properties = {username: username, password: password};
+                var idPServer = tokenUtil.getIdPServerURL();
+                if (tokenUtil.checkOAuthEnabled() && idPServer) {
+                    tokenUtil.setupAccessTokenPair(constants.GRANT_TYPE_PASSWORD, properties, idPServer, function (status) {
+                        if (!status) {
+                            log.error("Error while setting up access token and refresh token");
+                        }
+                    });
+                }
                 session.put('authToken', authToken);
-
                 if (dest) {
                     response.sendRedirect(dest);
                     return;
@@ -68,7 +80,6 @@ var dest;
                     response.sendRedirect(urlPrefix);
                     return;
                 }
-
                 response.sendRedirect(utils.tenantedPrefix(urlPrefix, user.domain));
                 return;
             }
@@ -76,7 +87,7 @@ var dest;
         message = 'incorrect.login.message';
         include(utils.resolvePath('templates/login.jag'));
     }
-    
+
     function createDir(path) {
         var file = new File(path);
         if (file.isExists()) {

--- a/apps/portal/modules/dashboards.js
+++ b/apps/portal/modules/dashboards.js
@@ -588,7 +588,7 @@ var getBootstrapLayout = function (pageId, isAnon) {
             }
             // decrease the row span by 1 since the current row is being processed.
             rowSpan--;
-            // if the rowSpan = 0, then we can safety split the above rows from the restservice
+            // if the rowSpan = 0, then we can safety split the above rows from the rest
             if (rowSpan == 0 || y == ey) {
                 endRow = y;
                 // if the heights of each block is not varying, then the section can be

--- a/apps/portal/modules/tokenUtil.js
+++ b/apps/portal/modules/tokenUtil.js
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var tokenUtil = function () {
+    var module = {};
+    var Base64 = Packages.org.apache.commons.codec.binary.Base64;
+    var String = Packages.java.lang.String;
+    var carbon = require('carbon');
+    var sso = require("sso");
+    var constants = require("/controllers/constants/constants.js");
+    var configs = require('/configs/portal.js').config();
+    var dashboards = require('/modules/dashboards.js');
+    var log = new Log("/utils/tokenUtil.js");
+
+    /**
+     * This will create client id and client secret for a given application
+     * @param properties    "callbackUrl": "",
+     *                      "clientName": "",
+     *                      "owner": "",
+     *                      "applicationType": "",
+     *                      "grantType": "",
+     *                      "saasApp" :"",
+     *                      "dynamicClientRegistrationEndPoint" : ""
+     *
+     * @returns {{clientId:*, clientSecret:*}}
+     */
+    module.getDynamicCredentials = function (properties) {
+        var payload = {
+            "callbackUrl": properties.callBackUrl,
+            "clientName": properties.clientName,
+            "tokenScope": properties.tokenScope,
+            "owner": properties.owner,
+            "applicationType": properties.applicationType,
+            "grantType": properties.grantType,
+            "saasApp": properties.saasApp
+        };
+        var xhr = new XMLHttpRequest();
+        var tokenEndpoint = properties.dynamicClientRegistrationEndPoint;
+        xhr.open(constants.HTTP_POST, tokenEndpoint, false);
+        xhr.setRequestHeader(constants.CONTENT_TYPE_IDENTIFIER, constants.APPLICATION_JSON);
+        xhr.send(payload);
+        var clientData = {};
+        if (xhr.status == 201) {
+            var data = parse(xhr.responseText);
+            clientData.clientId = data.client_id;
+            clientData.clientSecret = data.client_secret;
+        } else if (xhr.status == 400) {
+            throw "While creating an OAuth application. Invalid client meta data";
+        } else {
+            throw "Error while creating an OAuth application, obtaining client id and secret";
+        }
+        return clientData;
+    };
+
+    /**
+     * Encode the payload in Base64
+     * @param payload
+     * @returns {Packages.java.lang.String}
+     */
+    module.encode = function (payload) {
+        return new String(Base64.encodeBase64(new String(payload).getBytes()));
+    }
+
+    /**
+     * Decode the payload in Base64
+     * @param payload
+     * @returns {Packages.java.lang.String}
+     */
+    module.decode = function (payload) {
+        return new String(Base64.decodeBase64(new String(payload).getBytes()));
+    }
+
+    /**
+     * Get an AccessToken pair based on username and password
+     * @param username
+     * @param password
+     * @param encodedClientKeys  {{clientId:"", clientSecret:""}}
+     * @param scope              eg: PRODUCTION
+     * @returns {{accessToken: *, refreshToken: *}}
+     */
+    module.getTokenWithPasswordGrantType = function (username, password, encodedClientKeys, scope, idPServer) {
+        var xhr = new XMLHttpRequest();
+        var tokenEndpoint = idPServer;
+        xhr.open(constants.HTTP_POST, tokenEndpoint, false);
+        xhr.setRequestHeader(constants.CONTENT_TYPE_IDENTIFIER, constants.APPLICATION_X_WWW_FOR_URLENCODED);
+        xhr.setRequestHeader(constants.AUTHORIZATION_HEADER, constants.BASIC_PREFIX + encodedClientKeys);
+        xhr.send("grant_type=password&username=" + username + "&password=" + password + "&scope=" + scope);
+        delete password, delete clientSecret, delete encodedClientKeys;
+        var tokenPair = {};
+        if (xhr.status == 200) {
+            var data = parse(xhr.responseText);
+            tokenPair.refreshToken = data.refresh_token;
+            tokenPair.accessToken = data.access_token;
+        } else if (xhr.status == 403) {
+            log.error("Error in obtaining token with Password grant type, You are not authenticated yet");
+            return null;
+        } else {
+            log.error("Error in obtaining token with Password grant type, This might be a problem with client meta " +
+                "data which required for Password Grant type");
+            return null;
+        }
+        return tokenPair;
+    };
+
+    /**
+     * Get an AccessToken pair based on SAML assertion
+     * @param assertion           SAML assertion
+     * @param clientKeys          {{clientId:"", clientSecret:""}}
+     * @param scope               eg: PRODUCTION
+     * @param idPServer           identity provider ip address
+     * @returns {{accessToken: *, refreshToken: *}}
+     */
+    module.getTokenWithSAMLGrantType = function (assertion, clientKeys, scope, idPServer) {
+
+        var assertionXML = module.decode(assertion);
+        var encodedExtractedAssertion;
+        var extractedAssertion;
+        var assertionStartMarker = "<saml2:Assertion";
+        var assertionEndMarker = "<\/saml2:Assertion>";
+        var assertionStartIndex = assertionXML.indexOf(assertionStartMarker);
+        var assertionEndIndex = assertionXML.indexOf(assertionEndMarker);
+        if (assertionStartIndex != -1 && assertionEndIndex != -1) {
+            extractedAssertion = assertionXML.substring(assertionStartIndex, assertionEndIndex) + assertionEndMarker;
+        } else {
+            throw "Invalid SAML response. SAML response has no valid assertion string";
+        }
+
+        encodedExtractedAssertion = this.encode(extractedAssertion);
+
+        var xhr = new XMLHttpRequest();
+        var tokenEndpoint = idPServer;
+        xhr.open(constants.HTTP_POST, tokenEndpoint, false);
+        xhr.setRequestHeader(constants.CONTENT_TYPE_IDENTIFIER, constants.APPLICATION_X_WWW_FOR_URLENCODED);
+        xhr.setRequestHeader(constants.AUTHORIZATION_HEADER, constants.BASIC_PREFIX + clientKeys);
+        xhr.send("grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer&assertion=" +
+            encodeURIComponent(encodedExtractedAssertion) + "&scope=" + scope);
+        var tokenPair = {};
+        if (xhr.status == 200) {
+            var data = parse(xhr.responseText);
+            tokenPair.refreshToken = data.refresh_token;
+            tokenPair.accessToken = data.access_token;
+        } else if (xhr.status == 403) {
+            throw "Error in obtaining token with SAML extension grant type, You are not authenticated yet";
+        } else {
+            throw "Error in obtaining token with SAML Extension Grant type, This might be a problem with client meta " +
+            "data which required for SAML Extension Grant type";
+        }
+        return tokenPair;
+    };
+
+    /**
+     * Get an AccessToken pair once existing access token is expired using previous refresh token
+     * @param tokenPair     already existing access token and refresh token
+     * @param clientData    {{clientId:"", clientSecret:""}}
+     * @param scope         eg:PRODUCTION
+     * @param idPServer     identity provider ip address
+     * @returns {{accessToken: *, refreshToken: *}}
+     */
+    module.refreshToken = function (tokenPair, clientData, scope, idPServer) {
+        var xhr = new XMLHttpRequest();
+        var tokenEndpoint = idPServer;
+        xhr.open(constants.HTTP_POST, tokenEndpoint, false);
+        xhr.setRequestHeader(constants.CONTENT_TYPE_IDENTIFIER, constants.APPLICATION_X_WWW_FOR_URLENCODED);
+        xhr.setRequestHeader(constants.AUTHORIZATION_HEADER, constants.BASIC_PREFIX + clientData);
+        var url = "grant_type=refresh_token&refresh_token=" + tokenPair.refreshToken;
+        if (scope) {
+            url = url + "&scope=" + scope
+        }
+        xhr.send(url);
+        var tokenPair = {};
+        if (xhr.status == 200) {
+            var data = parse(xhr.responseText);
+            tokenPair.refreshToken = data.refresh_token;
+            tokenPair.accessToken = data.access_token;
+        } else if (xhr.status == 400) {
+            tokenPair = session.get(constants.ACCESS_TOKEN_PAIR_IDENTIFIER);
+        } else if (xhr.status == 403) {
+            throw "Error in obtaining token with Refresh Token  Grant Type, You are not authenticated yet";
+        } else {
+            throw "Error in obtaining token with  Refresh Token Type";
+        }
+        return tokenPair;
+    };
+
+    /**
+     * If access token is expired, try to refresh it using existing refresh token
+     * @param callback
+     */
+    module.refreshAccessToken = function (callback) {
+        try {
+            if (module.checkOAuthEnabled()) {
+                var clientCredentials;
+                var dynamicClientProperties = module.getDynamicClientProperties();
+                var applicationId = dynamicClientProperties.clientName;
+                dashboards.getOAuthApplication(applicationId, function (credentials) {
+                    if (credentials == null) {
+                        log.error("An OAuth application has not been created yet");
+                        callback(false);
+                    }
+                    clientCredentials = credentials;
+                    var encodedClientKeys = module.encode(clientCredentials.clientId + ":"
+                        + clientCredentials.clientSecret);
+                    var tokenPair = session.get(constants.ACCESS_TOKEN_PAIR_IDENTIFIER);
+                    tokenPair = module.refreshToken(tokenPair, encodedClientKeys,
+                        dynamicClientProperties.tokenScope, module.getIdPServerURL());
+                    session.put(constants.ACCESS_TOKEN_PAIR_IDENTIFIER, tokenPair);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Access token has been updated");
+                    }
+                    callback(true);
+                });
+            } else {
+                log.warn("You have not enable dynamic client yet");
+                callback(false);
+            }
+        } catch (exception) {
+            callback(false);
+            throw "Error while refreshing existing access token, " + exception;
+        }
+    }
+
+    /**
+     * Set access token into xml http request header
+     * @param xhr     xml http request
+     * @returns {*}   xhr which has access token it's header
+     */
+    module.setAccessToken = function (xhr, callback) {
+        var accessToken;
+        if (module.checkOAuthEnabled()) {
+            try {
+                accessToken = session.get(constants.ACCESS_TOKEN_PAIR_IDENTIFIER).accessToken;
+                xhr.setRequestHeader(constants.AUTHORIZATION_HEADER, constants.BEARER_PREFIX + accessToken);
+            } catch (exception) {
+                log.error("Access token hasn't been set yet, " + exception);
+            } finally {
+                callback(xhr);
+            }
+        }
+        callback(xhr);
+    }
+
+    /**
+     * Get access token of current logged user
+     * @param callBack response with access token
+     */
+    module.getAccessToken = function (callBack) {
+        var accessToken = null;
+        if (module.checkOAuthEnabled()) {
+            try {
+                accessToken = session.get(constants.ACCESS_TOKEN_PAIR_IDENTIFIER).accessToken;
+            } catch (exception) {
+                log.error("Access token hasn't been set yet, " + exception);
+            } finally {
+                callBack(accessToken);
+            }
+        }
+        callBack(accessToken);
+    }
+
+    /**
+     * Create error message which adhere to xml http response object
+     * @param statusCode       response status code
+     * @param status           response status
+     * @param responseText     response message
+     * @returns {{statusCode: *, status: *, responseText: *}}
+     */
+    module.createXHRObject = function (statusCode, status, responseText) {
+        return {"statusCode": statusCode, "status": status, "responseText": responseText};
+    }
+
+    /**
+     * Check whether this application is oauth enable or not
+     * @returns boolean if oauth enable
+     */
+    module.checkOAuthEnabled = function () {
+        if (constants.AUTHORIZATION_TYPE_OAUTH === configs.authorization.activeMethod) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get dynamic client registration configuration properties
+     * @returns {{"dynamicClientProperties": {
+                    "callbackUrl": "*",
+                    "clientName": "*",
+                    "owner": "*",
+                    "applicationType": "*",
+                    "grantType": "*",
+                    "saasApp": *,
+                    "dynamicClientRegistrationEndPoint": "*",
+                    "tokenScope": "*"
+                }}}
+     */
+    module.getDynamicClientProperties = function () {
+        return configs.authorization.methods.oauth.attributes.dynamicClientProperties;
+    }
+
+    /**
+     * Get set access token and refresh token according to given grant type: SAML, Password
+     * @param type           grate type: SAML, Password
+     * @param properties     Password Grant Type:{username: *, password: *}, SAML Grant Type : {samlToken:*, user:*}
+     * @param idPServer      identity provider url
+     * @param callBack       check whether access token and refresh token is correctly set or not
+     */
+    module.setupAccessTokenPair = function (type, properties, idPServer, callBack) {
+        var encodedClientKeys;
+        var clientCredentials;
+        var dynamicClientProperties = module.getDynamicClientProperties();
+        var applicationId = dynamicClientProperties.clientName;
+        try {
+            dashboards.getOAuthApplication(applicationId, function (credentials) {
+                if (credentials == null) {
+                    clientCredentials = module.getDynamicCredentials(dynamicClientProperties);
+                    if (dashboards.createOAuthApplication(applicationId, clientCredentials)) {
+                        log.info("An OAuth application has been created ageist this portal application");
+                    }
+                } else {
+                    clientCredentials = credentials;
+                }
+                encodedClientKeys = module.encode(clientCredentials.clientId + ":" +
+                    clientCredentials.clientSecret);
+                session.put(constants.ENCODED_CLIENT_KEYS_IDENTIFIER, encodedClientKeys);
+                if (type == constants.GRANT_TYPE_PASSWORD) {
+                    tokenPair = module.getTokenWithPasswordGrantType(properties.username, properties.password,
+                        encodedClientKeys, dynamicClientProperties.tokenScope, idPServer);
+                } else if (type == constants.GRANT_TYPE_SAML) {
+                    tokenPair = module.getTokenWithSAMLGrantType(properties.samlToken,
+                        encodedClientKeys, dynamicClientProperties.tokenScope, idPServer);
+                }
+                session.put(constants.ACCESS_TOKEN_PAIR_IDENTIFIER, tokenPair);
+            });
+            callBack(true);
+        } catch (exception) {
+            log.error("Error while setting up access token and refresh token, " + exception);
+            callBack(false);
+        }
+    }
+
+    /**
+     * check whether user already logged to system before invoking any apis
+     * @param callBack
+     */
+    module.isUserAuthorized = function (callBack) {
+        if (session.get("Loged") !== constants.LOGIN_MESSAGE) {
+            callBack(false);
+        } else {
+            callBack(true);
+        }
+    }
+
+    /**
+     * Get identity provider uir
+     * @returns {*}
+     */
+    module.getIdPServerURL = function () {
+        return configs.authorization.methods.oauth.attributes.idPServer;
+    }
+    return module;
+}();

--- a/apps/portal/modules/tokenUtil.js
+++ b/apps/portal/modules/tokenUtil.js
@@ -100,7 +100,6 @@ var tokenUtil = function () {
         xhr.setRequestHeader(constants.CONTENT_TYPE_IDENTIFIER, constants.APPLICATION_X_WWW_FOR_URLENCODED);
         xhr.setRequestHeader(constants.AUTHORIZATION_HEADER, constants.BASIC_PREFIX + encodedClientKeys);
         xhr.send("grant_type=password&username=" + username + "&password=" + password + "&scope=" + scope);
-        delete password, delete clientSecret, delete encodedClientKeys;
         var tokenPair = {};
         if (xhr.status == 200) {
             var data = parse(xhr.responseText);

--- a/components/shindig-wso2-features/src/main/javascript/wso2features/features.txt
+++ b/components/shindig-wso2-features/src/main/javascript/wso2features/features.txt
@@ -19,3 +19,4 @@ wso2features/identity/feature.xml
 wso2features/state/feature.xml
 wso2features/controls/feature.xml
 wso2features/navigate/feature.xml
+wso2features/remoteClient/feature.xml

--- a/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/HttpRequest.js
+++ b/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/HttpRequest.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+wso2.gadgets.HttpRequest  = (function () {
+    var module = this;
+    var END_POINT = "/portal/apis/HTTPClient";
+    var HTTP_GET = "GET";
+    var HTTP_POST = "POST";
+    var HTTP_PUT = "PUT";
+    var HTTP_DELETE = "DELETE";
+    var APPLICATION_JSON = "application/json";
+
+    module.get = function (url, successCallback, errorCallback, contentType, acceptType) {
+        var payload = null;
+        execute(HTTP_GET, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+    module.post = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        execute(HTTP_POST, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+    module.put = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        execute(HTTP_PUT, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+    module.delete = function (url, successCallback, errorCallback, contentType, acceptType) {
+        var payload = null;
+        execute(HTTP_DELETE, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+
+    function execute (method, url, payload, successCallback, errorCallback, contentType, acceptType) {
+        if(contentType == undefined){
+            contentType = APPLICATION_JSON;
+        }
+        if(acceptType == undefined){
+            acceptType = APPLICATION_JSON;
+        }
+        var data = {
+            url: END_POINT,
+            type: HTTP_POST,
+            contentType: contentType,
+            accept: acceptType,
+            success: successCallback,
+            error: errorCallback
+        };
+        var paramValue = {};
+        paramValue.actionMethod = method;
+        paramValue.actionUrl = url;
+        paramValue.actionPayload = payload;
+        data.data = JSON.stringify(paramValue);
+        $.ajax(data);
+    };
+    return {
+        get: module.get,
+        post: module.post,
+        put: module.put,
+        delete: module.delete
+    };
+})();

--- a/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/XMLHttpRequest.js
+++ b/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/XMLHttpRequest.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+wso2.gadgets.XMLHttpRequest  = (function () {
+    var module = this;
+    var END_POINT = "/portal/apis/XMLHTTPClient";
+    var HTTP_GET = "GET";
+    var HTTP_POST = "POST";
+    var HTTP_PUT = "PUT";
+    var HTTP_DELETE = "DELETE";
+    var APPLICATION_JSON = "application/json";
+
+    module.get = function (url, successCallback, errorCallback, contentType, acceptType) {
+        var payload = null;
+        execute(HTTP_GET, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+    module.post = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        execute(HTTP_POST, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+    module.put = function (url, payload, successCallback, errorCallback, contentType, acceptType) {
+        execute(HTTP_PUT, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+    module.delete = function (url, successCallback, errorCallback, contentType, acceptType) {
+        var payload = null;
+        execute(HTTP_DELETE, url, payload, successCallback, errorCallback, contentType, acceptType);
+    };
+
+    function execute (method, url, payload, successCallback, errorCallback, contentType, acceptType) {
+        if(contentType == undefined){
+            contentType = APPLICATION_JSON;
+        }
+        if(acceptType == undefined){
+            acceptType = APPLICATION_JSON;
+        }
+        var data = {
+            url: END_POINT,
+            type: HTTP_POST,
+            contentType: contentType,
+            accept: acceptType,
+            success: successCallback,
+            error: errorCallback
+        };
+        var paramValue = {};
+        paramValue.actionMethod = method;
+        paramValue.actionUrl = url;
+        paramValue.actionPayload = payload;
+        data.data = JSON.stringify(paramValue);
+        $.ajax(data);
+    };
+    return {
+        get: module.get,
+        post: module.post,
+        put: module.put,
+        delete: module.delete
+    };
+})();

--- a/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/feature.xml
+++ b/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/feature.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<feature>
+    <name>wso2-gadgets-remoteClient</name>
+    <dependency>wso2-gadgets-core</dependency>
+    <gadget>
+        <script src="XMLHttpRequest.js"></script>
+        <script src="HttpRequest.js"></script>
+    </gadget>
+</feature>

--- a/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/feature.xml
+++ b/components/shindig-wso2-features/src/main/javascript/wso2features/remoteClient/feature.xml
@@ -17,7 +17,6 @@
 
 <feature>
     <name>wso2-gadgets-remoteClient</name>
-    <dependency>wso2-gadgets-core</dependency>
     <gadget>
         <script src="XMLHttpRequest.js"></script>
         <script src="HttpRequest.js"></script>


### PR DESCRIPTION
If SSO is enabled, obtaining a token (OAuth2) using SAML Token and if SSO is disabled a token is generated (OAuth2) using password grant type. So when creating request from gadget level it will first redirected to remoteClient shindig feature. Afterwards, it will be redirected to either HTTPClient or XMLHTTPClient. This where an actual request is made to give backed REST service. If OAuth is enabled access token is being set in request header otherwise this part won't happen