### PR TITLE
Moving the fix of removing online features from product-ds to carbon-dashboards

### DIFF
--- a/components/shindig-server/pom.xml
+++ b/components/shindig-server/pom.xml
@@ -49,10 +49,54 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
                 <configuration>
                     <packagingExcludes>WEB-INF/lib/slf4j-*.jar</packagingExcludes>
                     <webXml>src/main/resources/web.xml</webXml>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <property name="tempdir" value="target/temp" />
+                                <unzip dest="${tempdir}/shindig">
+                                    <fileset dir="target/">
+                                        <include name="shindig-server-${carbon.dashboards.version}.war" />
+                                    </fileset>
+                                </unzip>
+                                <unzip dest="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}">
+                                    <fileset dir="${tempdir}/shindig/WEB-INF/lib">
+                                        <include name="shindig-extras-${shindig.version}.jar" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="target/shindig-server-${carbon.dashboards.version}.war" />
+                                <delete file="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}.jar" />
+                                <delete file="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}/features-extras/features.txt" />
+                                <copy todir="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}/features-extras/" overwrite="false">
+                                    <fileset dir="src/main/resources/">
+                                        <include name="features.txt" />
+                                    </fileset>
+                                </copy>
+                                <zip destfile="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}.jar" basedir="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}" />
+                                <delete dir="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}" />
+                                <zip destfile="target/shindig-server-${carbon.dashboards.version}.war" basedir="${tempdir}/shindig" />
+                                <delete dir="${tempdir}" />
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/components/shindig-server/src/main/resources/features.txt
+++ b/components/shindig-server/src/main/resources/features.txt
@@ -1,0 +1,25 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+features-extras/firebug-lite/feature.xml
+features-extras/org.jquery.core-1.4.2/feature.xml
+features-extras/wave/feature.xml
+features-extras/opensocial-payment/feature.xml
+features-extras/pubsub-2/feature.xml
+features-extras/org.openajax.hub-2.0.7/feature.xml
+features-extras/swfobject/feature.xml

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <apache.google.guice.version>3.0</apache.google.guice.version>
         <javax.servlet.api.version>2.5</javax.servlet.api.version>
+        <maven.antrunplugin.version>1.7</maven.antrunplugin.version>
     </properties>
 
     <scm>
@@ -173,6 +174,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${maven.antrunplugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This is to avoid start-up errors that can be caused by lack of internet connection. Removing the online features at carbon-dashboards level. 