### PR TITLE
Metadata API for view component

### DIFF
--- a/components/org.wso2.carbon.dashboards.metadata.api/pom.xml
+++ b/components/org.wso2.carbon.dashboards.metadata.api/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright 2016 (c) WSO2 Inc. (http://wso2.org) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.dashboards</groupId>
+        <artifactId>carbon-dashboards</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.dashboards.metadata.api</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Dashboards metadata store API</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.msf4j</groupId>
+            <artifactId>msf4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.dashboards</groupId>
+            <artifactId>org.wso2.carbon.dashboards.metadata</artifactId>
+            <version>${carbon.dashboards.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            org.wso2.carbon.dashboards.metadata.api.*;version="${version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.wso2.carbon.dashboards.metadata.*;version=${carbon.dashboards.version},
+                            org.wso2.msf4j.*;version="${msf4j-core.version}",
+                            javax.ws.rs.*
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/components/org.wso2.carbon.dashboards.metadata.api/src/main/java/org/wso2/carbon/dashboards/metadata/api/DataHolder.java
+++ b/components/org.wso2.carbon.dashboards.metadata.api/src/main/java/org/wso2/carbon/dashboards/metadata/api/DataHolder.java
@@ -1,0 +1,53 @@
+package org.wso2.carbon.dashboards.metadata.api;
+
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.dashboards.metadata.provider.MetadataProvider;
+
+/**
+ * This is the data holder for dashboards meta data API.
+ */
+@Component(name = "org.wso2.carbon.dashboards.metadata.api",
+        immediate = true)
+public class DataHolder {
+    private static MetadataProvider metadataProvider;
+
+    public static MetadataProvider getMetadataProvider() {
+        return metadataProvider;
+    }
+
+    @Reference(name = "metadataProvider",
+            service = MetadataProvider.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetMetadataProvider")
+    public void setMetadataProvider(MetadataProvider metadataProvider1) {
+        metadataProvider = metadataProvider1;
+    }
+
+    public void unsetMetadataProvider(MetadataProvider metadataProvider1) {
+        metadataProvider = null;
+    }
+}
+

--- a/components/org.wso2.carbon.dashboards.metadata.api/src/main/java/org/wso2/carbon/dashboards/metadata/api/MetadataProviderAPI.java
+++ b/components/org.wso2.carbon.dashboards.metadata.api/src/main/java/org/wso2/carbon/dashboards/metadata/api/MetadataProviderAPI.java
@@ -1,0 +1,92 @@
+package org.wso2.carbon.dashboards.metadata.api;
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import org.wso2.carbon.dashboards.metadata.bean.Metadata;
+import org.wso2.carbon.dashboards.metadata.bean.Query;
+import org.wso2.carbon.dashboards.metadata.exception.MetadataException;
+import org.wso2.carbon.dashboards.metadata.provider.MetadataProvider;
+import org.wso2.msf4j.Microservice;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * This is the API implementation for the meta data backend service.
+ */
+public class MetadataProviderAPI implements Microservice {
+
+    @POST
+    @Path("/add")
+    @Consumes("application/json")
+    @Produces("application/json")
+    public void add(Metadata metadata) throws MetadataException {
+        MetadataProvider metadataProvider = DataHolder.getMetadataProvider();
+        if (metadataProvider != null) {
+            metadataProvider.add(metadata);
+        }
+    }
+
+    @PUT
+    @Path("/update")
+    @Consumes("application/json")
+    @Produces("application/json")
+    public void update(Metadata metadata) throws MetadataException {
+        MetadataProvider metadataProvider = DataHolder.getMetadataProvider();
+        if (metadataProvider != null) {
+            metadataProvider.update(metadata);
+        }
+    }
+
+    @DELETE
+    @Path("/delete")
+    @Consumes("application/json")
+    @Produces("application/json")
+    public void delete(Query query) throws MetadataException {
+        MetadataProvider metadataProvider = DataHolder.getMetadataProvider();
+        if (metadataProvider != null) {
+            metadataProvider.delete(query);
+        }
+    }
+
+    @POST
+    @Consumes("application/json")
+    @Produces("application/json")
+    @Path("/get")
+    public Metadata get(Query query) throws MetadataException {
+        MetadataProvider metadataProvider = DataHolder.getMetadataProvider();
+        if (metadataProvider != null) {
+            return metadataProvider.get(query);
+        }
+        return null;
+    }
+
+
+    // todo: Remove this resource, this is just for testing
+    @GET
+    @Path("/sayHello")
+    public String sayHello() {
+        return "Hello!";
+    }
+}

--- a/components/org.wso2.carbon.dashboards.metadata/pom.xml
+++ b/components/org.wso2.carbon.dashboards.metadata/pom.xml
@@ -75,7 +75,7 @@
                     <instructions>
                         <Private-Package>org.wso2.carbon.dashboards.metadata.internal.*</Private-Package>
                         <Import-Package>
-                            org.wso2.carbon.uuf.*;version="${carbon.uuf.version}",
+                            org.wso2.carbon.uuf.*;version="${carbon.uuf.core.version}",
                             org.osgi.framework.*;version="[1.8.0, 2.0.0)",
                             <!--org.wso2.carbon.messaging;version="${carbon.messaging.version}",-->
                             <!--TODO: replace below line with above commented line after carbon-messaging fix export version issue.-->
@@ -91,8 +91,11 @@
                             javax.sql.*
                         </Import-Package>
                         <Export-Package>
-                            org.wso2.carbon.dashboards.metadata.*;version="${carbon.uuf.version}"
+                            org.wso2.carbon.dashboards.metadata.*;version="${carbon.dashboards.version}"
                         </Export-Package>
+                        <Carbon-Component>
+                            osgi.service;objectClass="org.wso2.carbon.dashboards.metadata.provider.MetadataProvider"
+                        </Carbon-Component>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.dashboards.metadata/src/main/java/org/wso2/carbon/dashboards/metadata/internal/provider/impl/MetadataProviderImpl.java
+++ b/components/org.wso2.carbon.dashboards.metadata/src/main/java/org/wso2/carbon/dashboards/metadata/internal/provider/impl/MetadataProviderImpl.java
@@ -44,7 +44,7 @@ import java.util.Map;
 /**
  * This is a core class of the Metadata business logic implementation.
  */
-@Component(name = "org.wso2.carbon.dashboard.metadata.internal.ServiceComponent",
+@Component(name = "org.wso2.carbon.dashboards.metadata.internal.provider.impl.MetadataProviderImpl",
            service = MetadataProvider.class,
            immediate = true)
 public class MetadataProviderImpl implements MetadataProvider {

--- a/components/org.wso2.carbon.dashboards.view/pom.xml
+++ b/components/org.wso2.carbon.dashboards.view/pom.xml
@@ -28,6 +28,11 @@
                         <goals>
                             <goal>create-component</goal>
                         </goals>
+                        <configuration>
+                            <instructions>
+                                <Import-Package>org.wso2.carbon.dashboards.metadata.api</Import-Package>
+                            </instructions>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/components/org.wso2.carbon.dashboards.view/src/main/component.yaml
+++ b/components/org.wso2.carbon.dashboards.view/src/main/component.yaml
@@ -1,0 +1,3 @@
+apis:
+    - className: "org.wso2.carbon.dashboards.metadata.api.MetadataProviderAPI"
+      uri: "/metadata/"

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>1</version>
+        <version>2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <modules>
         <module>components/org.wso2.carbon.dashboards.view</module>
         <module>components/org.wso2.carbon.dashboards.metadata</module>
+        <module>components/org.wso2.carbon.dashboards.metadata.api</module>
         <!-- <module>components/org.wso2.carbon.dashboards.designer</module>
         <module>components/org.wso2.carbon.dashboards.portal</module> -->
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <mockito-core.version>2.0.44-beta</mockito-core.version>
         <slf4j-api.version>1.7.5</slf4j-api.version>
         <slf4j-log4j12.version>1.6.0</slf4j-log4j12.version>
+        <slf4j.version.range>[1.7,2)</slf4j.version.range>
         <org.wso2.carbon.datasource.version.range>[1.0.0, 1.1.0)</org.wso2.carbon.datasource.version.range>
     </properties>
 


### PR DESCRIPTION
In this PR, the metadata provider backend service is registered as an OSGi and it is being consumed by the metadata provider API. Metadata provider API is an MSF4J service, a REST API, which is intended to be deployed at the application deployment.

The API currently supports add, delete, update and get for metadata. The implementation ATM is a pass through to the metadata provider backend, we may improve it as required.