### PR TITLE
Fix issue in add block function

### DIFF
--- a/components/org.wso2.carbon.dashboards.designer/src/main/fragments/dashboard-designer/public/js/designer.js
+++ b/components/org.wso2.carbon.dashboards.designer/src/main/fragments/dashboard-designer/public/js/designer.js
@@ -465,7 +465,7 @@
             data.widget.pubsub = pubsub;
             UUFClient.renderFragment(Constants.WIDGET_CONTAINER_FRAGMENT_NAME, {
                 blocks: [data]
-            }, 'gridContent', 'APPEND', {
+            }, {
                 onSuccess: function (data) {
                     $('.grid-stack').data('gridstack').add_widget(data, 0, 0, width, height);
                     updateLayout();


### PR DESCRIPTION
This PR resolves #530 i.e. Widget cannot be added to a newly added block in a page.