### PR TITLE
Add Widget State Persistance

### DIFF
--- a/components/dashboards-web-component/src/DashboardListing.jsx
+++ b/components/dashboards-web-component/src/DashboardListing.jsx
@@ -59,13 +59,13 @@ class DashboardListing extends React.Component {
     retrieveDashboards() {
         let dashboardAPIs = new DashboardsAPIs();
         let promised_dashboard_list = dashboardAPIs.getDashboardList();
-        let thisRef = this;
+        let that = this;
         promised_dashboard_list.then((response) => {
                 let dashboardList;
                 dashboardList = response.data.map(dashboard => {
-                    return <DashboardThumbnail dashboard={dashboard}/>;
+                    return <DashboardThumbnail dashboard={dashboard} muiTheme={muiTheme}/>;
                 });
-                thisRef.setState({dashboard: dashboardList});
+                that.setState({dashboards: dashboardList});
             }).catch(function (error) {
                 //TODO Need to use proper notification library to show the error
             }

--- a/components/dashboards-web-component/src/DashboardRenderingComponent.jsx
+++ b/components/dashboards-web-component/src/DashboardRenderingComponent.jsx
@@ -33,6 +33,11 @@ class DashboardRenderingComponent extends React.Component {
         this.renderDashboard = this.renderDashboard.bind(this);
         this.loadWidget = this.loadWidget.bind(this);
         this.findWidget = this.findWidget.bind(this);
+        this.updateLayout = this.updateLayout.bind(this);
+    }
+
+    updateLayout() {
+        dashboardLayout.updateSize();
     }
 
     render() {

--- a/components/dashboards-web-component/src/DashboardThumbnail.jsx
+++ b/components/dashboards-web-component/src/DashboardThumbnail.jsx
@@ -32,18 +32,14 @@ class DashboardThumbnail extends React.Component {
             },
             subtitle: {
                 "color": this.props.muiTheme.palette.alternateTextColor
-            },
-            buttons: {
-                "margin-right": "15px"
             }
-        }
+        };
 
         return (
             <div className="dashboard-thumbnail">
                 <div style={styles.card} className="content">
                     <h4 style={styles.title}>{this.props.dashboard.name}</h4>
                     <p style={styles.subtitle}>{this.props.dashboard.description}</p>
-
                     <div className="actions">
                         <Link to={"dashboards/" + this.props.dashboard.url}>
                             <span className="fw-stack icon">

--- a/components/dashboards-web-component/src/DashboardView.jsx
+++ b/components/dashboards-web-component/src/DashboardView.jsx
@@ -52,6 +52,10 @@ class DashboardView extends React.Component {
             open: !this.state.open,
             contentClass: this.state.open ? "content-drawer-closed" : "content-drawer-opened"
         });
+        var that = this;
+        setTimeout(function() {
+            that.dashboardRenderingComponent.updateLayout();
+        }, 100);
     }
 
     componentDidMount() {
@@ -138,7 +142,7 @@ class DashboardView extends React.Component {
                             onLeftIconButtonTouchTap={this.handleToggle}
                         />
                         <div id="dashboard-view" className={this.state.dashboardViewCSS}></div>
-                        <DashboardRenderingComponent
+                        <DashboardRenderingComponent ref={(c) => {this.dashboardRenderingComponent = c;}}
                             dashboardContent={this.getDashboardByPageId(this.props.match.params[1], this.state.dashboardContent)} />
                         
                     </div>

--- a/components/dashboards-web-component/src/widget/Widget.jsx
+++ b/components/dashboards-web-component/src/widget/Widget.jsx
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+
+export default class Widget extends Component {
+    constructor() {
+        super();
+        this.getDashboardAPI = this.getDashboardAPI.bind(this);
+    }
+
+    render () {
+        return (
+            <div>  
+                {this.renderWidget()}
+            </div>
+        );
+    }
+
+    /**
+     * Returns the dashboards API functions.
+     */
+    getDashboardAPI() {
+        let that = this;
+        function getStateObject() {
+            // De-serialize the object in suitable format
+            return (window.location.hash === '' || window.location.hash === '#') ? 
+                {} : JSON.parse(window.location.hash.substr(1));   
+        }
+
+        function setStateObject(state) {
+            // Serialize the object in suitable format
+            window.location.hash = JSON.stringify(state);
+        }
+
+        function getLocalState() {
+            let allStates = getStateObject();
+            return allStates.hasOwnProperty(that.props.id) ? allStates[that.props.id] : {};
+        }
+
+        function setLocalState(state) {
+            let allStates = getStateObject();
+            allStates[that.props.id] = state;
+            setStateObject(allStates);
+        } 
+
+        return {
+            state: {
+                get: function(key) {
+                    let state = getLocalState();
+                    return state.hasOwnProperty(key) ? state[key] : null; 
+                },
+                set: function(key, value) {
+                    let state = getLocalState();
+                    state[key] = value;
+                    setLocalState(state);
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR introduces widget state persistence when sharing dashboards (resolves https://github.com/wso2/carbon-dashboards/issues/566). In order to persist and retrieve the state of the widget a set of client-side APIs are exposed to widget using the `Widget` parent component. 

## Creating a widget

In order to use the widget capabilities provided by the dashboard, a widget needs to extend from `Widget` component.

```js
import React, { Component } from 'react';
import Widget from './Widget'

class SampleWidget extends Widget {
   /* ... */
}
```

## Persisting and retrieving widget states

### Persisting widget state

```js
/* ... */

class SampleWidget extends Widget {
    /* ... */
    setWidegtState() {
        super.getDashboardAPI().state.set('level', 4);
    }
    /* ... */
}
```

### Retrieving widget state

```js
/* ... */
class SampleWidget extends Widget {
    /* ... */
    getWidgetState() {
        let currentLevel = super.getDashboardAPI().state.get('level');
    }    
    /* ... */
}
```