### PR TITLE
Carbon Kernel 5.2.0-alpha Migration

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
@@ -79,7 +79,7 @@
                             org.slf4j.*;version="${slf4j.version.range}",
                             com.google.gson.*;version="[2.2.4,3)",
                             javax.sql.*,
-                            org.wso2.carbon.config.*
+                            org.wso2.carbon.config.*;version="${carbon.config.version.range}"
                         </Import-Package>
                         <Export-Package>
                             org.wso2.carbon.dashboards.core.*;version="${carbon.dashboards.version}",

--- a/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
@@ -79,7 +79,7 @@
                             org.slf4j.*;version="${slf4j.version.range}",
                             com.google.gson.*;version="[2.2.4,3)",
                             javax.sql.*,
-                            org.wso2.carbon.kernel.*
+                            org.wso2.carbon.config.*
                         </Import-Package>
                         <Export-Package>
                             org.wso2.carbon.dashboards.core.*;version="${carbon.dashboards.version}",

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardConfigurations.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardConfigurations.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.dashboards.core.bean;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration bean class for dashboard configurations.
+ */
+@Configuration(namespace = "wso2.dashboard", description = "WSO2 Dashboard configuration object")
+public class DashboardConfigurations {
+    @Element(description = "Database query map")
+    private Map<String, Map<String, String>> queries = new HashMap<>();
+
+    public DashboardConfigurations() {
+    }
+
+    public Map<String, Map<String, String>> getQueries() {
+        return queries;
+    }
+
+    public void setQueries(Map<String, Map<String, String>> queries) {
+        this.queries = queries;
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DataHolder.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DataHolder.java
@@ -18,7 +18,7 @@
  */
 package org.wso2.carbon.dashboards.core.internal;
 
-import org.wso2.carbon.kernel.configprovider.ConfigProvider;
+import org.wso2.carbon.config.provider.ConfigProvider;
 
 /**
  * This is data holder for config provider implementations.

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/ServiceComponent.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/ServiceComponent.java
@@ -22,7 +22,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.wso2.carbon.kernel.configprovider.ConfigProvider;
+import org.wso2.carbon.config.provider.ConfigProvider;
 
 /**
  * This is OSGi-components to register config provider class.
@@ -33,6 +33,12 @@ import org.wso2.carbon.kernel.configprovider.ConfigProvider;
         immediate = true
 )
 public class ServiceComponent {
+    /**
+     * Get the ConfigProvider service.
+     * This is the bind method that gets called for ConfigProvider service registration that satisfy the policy.
+     *
+     * @param configProvider the ConfigProvider service that is registered as a service.
+     */
     @Reference(
             name = "carbon.config.provider",
             service = ConfigProvider.class,
@@ -44,6 +50,11 @@ public class ServiceComponent {
         DataHolder.getInstance().setConfigProvider(configProvider);
     }
 
+    /**
+     * This is the unbind method for the above reference that gets called for ConfigProvider instance un-registrations.
+     *
+     * @param configProvider the ConfigProvider service that get unregistered.
+     */
     protected void unregisterConfigProvider(ConfigProvider configProvider) {
         DataHolder.getInstance().setConfigProvider(null);
     }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/dao/utils/QueryManager.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/dao/utils/QueryManager.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.dashboards.core.internal.dao.utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.dashboards.core.bean.DashboardConfigurations;
 import org.wso2.carbon.dashboards.core.internal.DataHolder;
 
 import java.util.HashMap;
@@ -46,27 +48,17 @@ public class QueryManager {
         // TODO: Get the relevant type of the database from the config provider.
         String databaseType = "h2";
 
+        ConfigProvider configProvider = DataHolder.getInstance().getConfigProvider();
         try {
-            Map dashboardConfigs = DataHolder.getInstance().getConfigProvider().getConfigurationMap("wso2.dashboard");
-
-            if (null != dashboardConfigs) {
-                if (dashboardConfigs.containsKey("db_queries") && null != dashboardConfigs.get("db_queries")) {
-                    Map databaseTypes = (Map) dashboardConfigs.get("db_queries");
-                    if (null != databaseTypes && databaseTypes.containsKey(databaseType)) {
-                        Map dbQueries = (Map<String, String>) databaseTypes.get(databaseType);
-                        return (null != dbQueries) ? dbQueries : new HashMap<>();
-                    } else {
-                        throw new RuntimeException("Unable to find the database type: " + databaseType);
-                    }
-                } else {
-                    throw new RuntimeException("Unable to find database queries in the deployment.yaml");
-                }
+            DashboardConfigurations dashboardConfigurations = configProvider
+                    .getConfigurationObject(DashboardConfigurations.class);
+            if (!dashboardConfigurations.getQueries().containsKey(databaseType)) {
+                throw new RuntimeException("Unable to find the database type: " + databaseType);
             }
-
+            return dashboardConfigurations.getQueries().get(databaseType);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
         }
-
         return new HashMap<>();
     }
 

--- a/features/org.wso2.carbon.dashboards.api.feature/src/main/resources/p2.inf
+++ b/features/org.wso2.carbon.dashboards.api.feature/src/main/resources/p2.inf
@@ -1,3 +1,2 @@
 instructions.configure = \
-org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.dashboards.api_${feature.version}/conf/dashboard-datasources.xml/,target:${installFolder}/../../conf/datasources/dashboard-datasources.xml,overwrite:true);\
-org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.dashboards.api_${feature.version}/repository/database/DASHBOARD_DB.h2.db/,target:${installFolder}/../../database/DASHBOARD_DB.h2.db,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.dashboards.api_${feature.version}/repository/database/DASHBOARD_DB.h2.db/,target:${installFolder}/../../wso2/default/database/DASHBOARD_DB.h2.db,overwrite:true);\

--- a/pom.xml
+++ b/pom.xml
@@ -119,21 +119,24 @@
     <properties>
         <project.scm.id>github-scm</project.scm.id>
         <carbon.dashboards.version>4.0.0-SNAPSHOT</carbon.dashboards.version>
-        <carbon.datasource.core.version>1.1.2</carbon.datasource.core.version>
         <carbon.messaging.version>2.3.2</carbon.messaging.version>
         <msf4j-core.version>2.3.0-m2</msf4j-core.version>
         <slf4j-api.version>1.7.5</slf4j-api.version>
         <slf4j-log4j12.version>1.6.0</slf4j-log4j12.version>
         <slf4j.version.range>[1.7,2)</slf4j.version.range>
-        <org.wso2.carbon.datasource.version.range>[1.0.0, 2.0.0)</org.wso2.carbon.datasource.version.range>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <gson.version>2.2.4</gson.version>
         <gson.version.range>[2.2.4,3)</gson.version.range>
+
+        <!-- Datasource -->
+        <carbon.datasource.core.version>1.1.2</carbon.datasource.core.version>
+        <org.wso2.carbon.datasource.version.range>[1.0.0, 2.0.0)</org.wso2.carbon.datasource.version.range>
 
         <!--Config-->
         <carbon.config.version>2.0.3</carbon.config.version>
         <carbon.securevault.version>5.0.8</carbon.securevault.version>
         <carbon.utils.version>2.0.2</carbon.utils.version>
+        <carbon.config.version.range>[2.0.0, 3.0.0)</carbon.config.version.range>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,6 @@
                 <version>${msf4j-core.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${testng.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito-core.version}</version>
@@ -93,10 +88,30 @@
                 <artifactId>org.wso2.carbon.dashboards.sample.store.provider</artifactId>
                 <version>${carbon.dashboards.version}</version>
             </dependency>
+
+            <!--Config-->
             <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.core</artifactId>
-                <version>${carbon.kernel.version}</version>
+                <groupId>org.wso2.carbon.config</groupId>
+                <artifactId>org.wso2.carbon.config</artifactId>
+                <version>${carbon.config.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.config</groupId>
+                <artifactId>org.wso2.carbon.config.feature</artifactId>
+                <version>${carbon.config.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.secvault</groupId>
+                <artifactId>org.wso2.carbon.secvault.feature</artifactId>
+                <version>${carbon.securevault.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.utils</groupId>
+                <artifactId>org.wso2.carbon.utils.feature</artifactId>
+                <version>${carbon.utils.version}</version>
+                <type>zip</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -104,17 +119,21 @@
     <properties>
         <project.scm.id>github-scm</project.scm.id>
         <carbon.dashboards.version>4.0.0-SNAPSHOT</carbon.dashboards.version>
-        <carbon.kernel.version>5.2.0-m3</carbon.kernel.version>
-        <carbon.datasource.core.version>1.1.0</carbon.datasource.core.version>
+        <carbon.datasource.core.version>1.1.2</carbon.datasource.core.version>
         <carbon.messaging.version>2.3.2</carbon.messaging.version>
         <msf4j-core.version>2.3.0-m2</msf4j-core.version>
         <slf4j-api.version>1.7.5</slf4j-api.version>
         <slf4j-log4j12.version>1.6.0</slf4j-log4j12.version>
         <slf4j.version.range>[1.7,2)</slf4j.version.range>
-        <org.wso2.carbon.datasource.version.range>[1.0.0, 1.1.0]</org.wso2.carbon.datasource.version.range>
+        <org.wso2.carbon.datasource.version.range>[1.0.0, 2.0.0)</org.wso2.carbon.datasource.version.range>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <gson.version>2.2.4</gson.version>
         <gson.version.range>[2.2.4,3)</gson.version.range>
+
+        <!--Config-->
+        <carbon.config.version>2.0.3</carbon.config.version>
+        <carbon.securevault.version>5.0.8</carbon.securevault.version>
+        <carbon.utils.version>2.0.2</carbon.utils.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
This PR contains the Carbon Kernel migration to version 5.2.0-alpha.

This includes changes related to `carbon-configs` and  `carbon-datasources`, which requires configuration changes in the `deployment.yaml` file. Please add the following configurations into the `deployment.yaml` file.

```yaml
# Dashboard related configurations
wso2.dashboard:
  queries:
    h2:
      add_dashboard: INSERT INTO DASHBOARD_RESOURCE (DASHBOARD_URL, DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_PARENT_ID , DASHBOARD_LANDING_PAGE, DASHBOARD_CONTENT) VALUES (?, ?, ?, ?, ?, ?)
      get_dashboard_by_url: SELECT DASHBOARD_ID, DASHBOARD_URL, DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_PARENT_ID, DASHBOARD_LANDING_PAGE, DASHBOARD_CONTENT FROM DASHBOARD_RESOURCE WHERE DASHBOARD_URL = ?
      get_dashboard_metadata_list: SELECT DASHBOARD_ID, DASHBOARD_URL, DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_PARENT_ID, DASHBOARD_LANDING_PAGE FROM DASHBOARD_RESOURCE 
      delete_dashboard_by_url: DELETE FROM DASHBOARD_RESOURCE WHERE DASHBOARD_URL = ?	
      update_dashboard_content: MERGE INTO DASHBOARD_RESOURCE (DASHBOARD_NAME, DASHBOARD_DESCRIPTION, DASHBOARD_CONTENT, DASHBOARD_URL, DASHBOARD_PARENT_ID, DASHBOARD_LANDING_PAGE) KEY(DASHBOARD_URL) VALUES( ?, ?, ?, ?, ?, ?)

# Data Sources Configuration
wso2.datasources:
  dataSources:
  # Dashboard data source
  - name: WSO2_DASHBOARD_DB
    description: The datasource used for dashboard feature
    jndiConfig:
      name: jdbc/DASHBOARD_DB
      useJndiReference: true
    definition:
      type: RDBMS
      configuration:
        jdbcUrl: 'jdbc:h2:./database/DASHBOARD_DB;IFEXISTS=TRUE;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE'
        username: wso2carbon
        password: wso2carbon
        driverClassName: org.h2.Driver
        maxPoolSize: 50
        idleTimeout: 60000
        connectionTestQuery: SELECT 1
        validationTimeout: 30000
        isAutoCommit: false
```