### PR TITLE
Adding localization support with react-intl

### DIFF
--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -27,6 +27,7 @@
     "material-ui": "^0.19.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "react-intl": "^2.4.0",
     "react-router-dom": "^4.1.2",
     "react-shadow": "^2.0.2",
     "recharts": "^1.0.0-alpha.2",

--- a/components/dashboards-web-component/pom.xml
+++ b/components/dashboards-web-component/pom.xml
@@ -102,6 +102,10 @@
                 <targetPath>js</targetPath>
             </resource>
             <resource>
+                <directory>${basedir}/public/locales</directory>
+                <targetPath>locales</targetPath>
+            </resource>
+            <resource>
                 <directory>${basedir}/public</directory>
                 <includes>
                     <include>index.html</include>

--- a/components/dashboards-web-component/pom.xml
+++ b/components/dashboards-web-component/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m9-SNAPSHOT</version>
+        <version>4.0.0.m10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/dashboards-web-component/public/locales/en.json
+++ b/components/dashboards-web-component/public/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "dashboard.name" : "Name of your Dashboard",
+  "dashboard.url" : "URL",
+  "dashboard.description" : "Description"
+}

--- a/components/dashboards-web-component/public/locales/fr.json
+++ b/components/dashboards-web-component/public/locales/fr.json
@@ -1,0 +1,5 @@
+{
+  "dashboard.name" : "Nom de votre tableau de bord",
+  "dashboard.url" : "URL",
+  "dashboard.description" : "La description"
+}

--- a/components/dashboards-web-component/src/App.jsx
+++ b/components/dashboards-web-component/src/App.jsx
@@ -19,6 +19,8 @@
 
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
+import axios from 'axios';
+import {addLocaleData, defineMessages, IntlProvider} from 'react-intl';
 import {BrowserRouter, Route, Link, Switch} from 'react-router-dom';
 // App components
 import DashboardView from './viewer/DashboardView';
@@ -27,26 +29,63 @@ import DashboardDesigner from './designer/DashboardDesigner';
 import DashboardCreate from './designer/DashboardCreatePage';
 import DashboardSettings from './designer/DashboardSettings';
 
+//TODO: take appContext from UI server utility
+const publicPath = '/portal/public/app/';
+const language = (navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage;
+const languageWithoutRegionCode = language.toLowerCase().split(/[_-]+/)[0];
+
 class App extends Component {
+    constructor() {
+        super();
+        this.state = {
+            messages: {}
+        }
+
+    };
+    
+    componentWillMount(){
+        let localeFileName = (languageWithoutRegionCode || language || 'en');
+        let that = this;
+        axios.get(window.location.origin + publicPath + 'locales/' + localeFileName + '.json')
+            .then(function (response) {
+                addLocaleData(require('react-intl/locale-data/' + localeFileName));
+                that.setState({
+                    messages: defineMessages(response.data)
+                });
+            })
+            .catch(function (error) {
+                axios.get(window.location.origin + publicPath + 'locales/en.json')
+                    .then(function (response) {
+                        addLocaleData(require('react-intl/locale-data/en'));
+                        that.setState({
+                            messages: defineMessages(response.data)
+                        });
+                    }).catch(function (error) {
+                });
+            });
+
+    }
     render () {
         // TODO portal is the app context. Need to get the app context properly and use here
         return (
-            <BrowserRouter history>
-                <Switch>
-                    {/* Dashboard listing a.k.a. landing page */}
-                    <Route exact path='/portal' component={DashboardListing}/>
-                    {/* Create dashboard */}
-                    <Route exact path='/portal/create' component={DashboardCreate}/>
-                    {/* Dashboard settings */}
-                    <Route exact path='/portal/settings/:id' component={DashboardSettings}/>
-                    {/* Dashboard designer */}
-                    <Route exact path='*/designer/:dashboardId' component={DashboardDesigner}/>
-                    <Route path='*/designer/:dashboardId/*' component={DashboardDesigner}/>
-                    {/* Dashboard view */}
-                    <Route exact path='*/dashboards/:id' component={DashboardView}/>
-                    <Route path='*/dashboards/:id/*' component={DashboardView}/>
-                </Switch>
-            </BrowserRouter>
+            <IntlProvider locale={language} messages={this.state.messages}>
+                <BrowserRouter history>
+                    <Switch>
+                        {/* Dashboard listing a.k.a. landing page */}
+                        <Route exact path='/portal' component={DashboardListing}/>
+                        {/* Create dashboard */}
+                        <Route exact path='/portal/create' component={DashboardCreate}/>
+                        {/* Dashboard settings */}
+                        <Route exact path='/portal/settings/:id' component={DashboardSettings}/>
+                        {/* Dashboard designer */}
+                        <Route exact path='*/designer/:dashboardId' component={DashboardDesigner}/>
+                        <Route path='*/designer/:dashboardId/*' component={DashboardDesigner}/>
+                        {/* Dashboard view */}
+                        <Route exact path='*/dashboards/:id' component={DashboardView}/>
+                        <Route path='*/dashboards/:id/*' component={DashboardView}/>
+                    </Switch>
+                </BrowserRouter>
+            </IntlProvider>
         );
     }
 }

--- a/components/dashboards-web-component/src/designer/DashboardCreatePage.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardCreatePage.jsx
@@ -32,6 +32,8 @@ import Header from '../common/Header';
 import DashboardAPIS from '../utils/apis/DashboardAPIs';
 import DashboardUtils from '../utils/DashboardUtils';
 
+import {FormattedMessage} from 'react-intl';
+
 const muiTheme = getMuiTheme(darkBaseTheme);
 const hintStyle = {color: "grey", bottom: 0};
 const textareaStyle = {color: "black"};
@@ -80,7 +82,8 @@ class DashboardCreatePage extends React.Component {
                     <Divider className="create-dashboard-divider"/>
                     <div className="create-dashboard-form-group">
                         <label className="create-dashboard-page-label-name">
-                            Name of your Dashboard <span className="required">*</span>
+                            <FormattedMessage id="dashboard.name" defaultMessage="Name of your Dashboard"/>
+                            <span className="required">*</span>
                         </label>
                         <TextField errorText={this.state.errorMessageName} errorStyle={this.state.errorStyleName}
                                    onChange={this.handleDashboardName} id="dashboardName" hintStyle={hintStyle}
@@ -90,7 +93,8 @@ class DashboardCreatePage extends React.Component {
                     </div>
                     <div className="create-dashboard-form-group">
                         <label className="create-dashboard-page-label-url">
-                            URL <span className="required">*</span>
+                            <FormattedMessage id="dashboard.url" defaultMessage="URL"/>
+                            <span className="required">*</span>
                         </label>
                         <TextField errorText={this.state.errorMessageURL} errorStyle={this.state.errorStyleURL}
                                    onChange={this.handleURL} value={this.state.url} id="dashboardURL"
@@ -100,7 +104,7 @@ class DashboardCreatePage extends React.Component {
                     </div>
                     <div className="create-dashboard-form-group">
                         <label className="create-dashboard-page-label-description">
-                            Description
+                            <FormattedMessage id="dashboard.description" defaultMessage="Description"/>
                         </label>
                         <TextField id="dashboardDescription" hintStyle={hintStyle} textareaStyle={textareaStyle}
                                    underlineStyle={underlineStyle} style={textFieldStyle}

--- a/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m9-SNAPSHOT</version>
+        <version>4.0.0.m10-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m9-SNAPSHOT</version>
+        <version>4.0.0.m10-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.dashboards.api.feature/pom.xml
+++ b/features/org.wso2.carbon.dashboards.api.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m9-SNAPSHOT</version>
+        <version>4.0.0.m10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.dashboards.portal.feature/pom.xml
+++ b/features/org.wso2.carbon.dashboards.portal.feature/pom.xml
@@ -71,6 +71,15 @@
                                     <version>${project.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/target/portal/public/</outputDirectory>
+                                    <includes>locales/**</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.dashboards</groupId>
+                                    <artifactId>dashboards-web-component</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/target/portal/</outputDirectory>
                                     <includes>pages/index.html</includes>
                                 </artifactItem>

--- a/features/org.wso2.carbon.dashboards.portal.feature/pom.xml
+++ b/features/org.wso2.carbon.dashboards.portal.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m9-SNAPSHOT</version>
+        <version>4.0.0.m10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.wso2.carbon.dashboards</groupId>
     <artifactId>carbon-dashboards</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.1.m9-SNAPSHOT</version>
+    <version>4.0.0.m10-SNAPSHOT</version>
     <name>WSO2 Carbon Dashboards</name>
     <url>http://wso2.org</url>
 
@@ -123,7 +123,7 @@
 
     <properties>
         <project.scm.id>github-scm</project.scm.id>
-        <carbon.dashboards.version>4.0.1.m9-SNAPSHOT</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.0.m10-SNAPSHOT</carbon.dashboards.version>
         <carbon.messaging.version>2.3.2</carbon.messaging.version>
         <carbon.ui.server.version>0.9.1</carbon.ui.server.version>
         <carbon.ui.sever.version.range>[0.0.0,1.0.0]</carbon.ui.sever.version.range>


### PR DESCRIPTION
## Purpose
For dashboard app to be used outside the English-speaking world, we’ll have to adapt all our strings, dates, and numbers to the conventions of different locales.

## Goals
This feature will enable localization support for the react app

## Approach
A third party library called react-intl is used to get the localization support.

## Documentation
Locale files will be at HOME/deployment/reactapps/portal/public/locales/
Any new locale files can be added with the name of the locale either with the region code or not.
Ex: en.json, fr.json

## Samples
en.json and fr.json files are added in the app for reference.