### PR TITLE
Add Maven profiles for different OSs in web component's pom.xml

### DIFF
--- a/components/dashboards-web-component/pom.xml
+++ b/components/dashboards-web-component/pom.xml
@@ -89,7 +89,7 @@
                             <executable>${npm.executable}</executable>
                             <arguments>
                                 <argument>run</argument>
-                                <argument>${npm.build.command}</argument>
+                                <argument>build</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -117,6 +117,5 @@
 
     <properties>
         <npm.executable>npm</npm.executable>
-        <npm.build.command>build</npm.build.command>
     </properties>
 </project>

--- a/components/dashboards-web-component/pom.xml
+++ b/components/dashboards-web-component/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m11-SNAPSHOT</version>
+        <version>4.0.0.m12-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/dashboards-web-component/pom.xml
+++ b/components/dashboards-web-component/pom.xml
@@ -14,7 +14,8 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
@@ -115,7 +116,37 @@
         </resources>
     </build>
 
-    <properties>
-        <npm.executable>npm</npm.executable>
-    </properties>
+    <profiles>
+        <profile>
+            <id>platform-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <npm.executable>npm.cmd</npm.executable>
+            </properties>
+        </profile>
+        <profile>
+            <id>platform-unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <properties>
+                <npm.executable>npm</npm.executable>
+            </properties>
+        </profile>
+        <profile>
+            <id>platform-default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <npm.executable>npm</npm.executable>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m11-SNAPSHOT</version>
+        <version>4.0.0.m12-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m11-SNAPSHOT</version>
+        <version>4.0.0.m12-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.dashboards.api.feature/pom.xml
+++ b/features/org.wso2.carbon.dashboards.api.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m11-SNAPSHOT</version>
+        <version>4.0.0.m12-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.dashboards.portal.feature/pom.xml
+++ b/features/org.wso2.carbon.dashboards.portal.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.dashboards</groupId>
         <artifactId>carbon-dashboards</artifactId>
-        <version>4.0.1.m11-SNAPSHOT</version>
+        <version>4.0.0.m12-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.wso2.carbon.dashboards</groupId>
     <artifactId>carbon-dashboards</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.1.m11-SNAPSHOT</version>
+    <version>4.0.0.m12-SNAPSHOT</version>
     <name>WSO2 Carbon Dashboards</name>
     <url>http://wso2.org</url>
 
@@ -123,7 +123,7 @@
 
     <properties>
         <project.scm.id>github-scm</project.scm.id>
-        <carbon.dashboards.version>4.0.1.m11-SNAPSHOT</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.0.m12-SNAPSHOT</carbon.dashboards.version>
         <carbon.messaging.version>2.3.2</carbon.messaging.version>
         <carbon.ui.server.version>0.9.1</carbon.ui.server.version>
         <carbon.ui.sever.version.range>[0.0.0,1.0.0]</carbon.ui.sever.version.range>


### PR DESCRIPTION
## Purpose
Cannot build `carbon-dashboards` in Windows.
Fixes #614 

## Goals
Ability to build `carbon-dashboards`d in Windows.

## Approach
Added Maven profiles for different OSs (Windows & Unix) in the `pom.xml` of `dashboards-web-component`. Also added a default profile that will be activated if non-other is active.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Test environment
- OS: Windows 7
  - Node: v6.11.4
  - NPM: 3.10.10
  - Maven: v3.2.2
  - Java: 1.8._112
 - OS: Ubuntu 16.04
   - Node: v6.11.4
   - NPM: 3.10.10
   - Maven: v3.2.2
   - Java: 1.8._112
