### PR TITLE
Integrate authentication

### DIFF
--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -25,6 +25,7 @@
     "golden-layout": "^1.5.9",
     "html-loader": "^0.5.0",
     "material-ui": "^0.19.0",
+    "qs": "^6.5.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-intl": "^2.4.0",

--- a/components/dashboards-web-component/src/auth/Login.jsx
+++ b/components/dashboards-web-component/src/auth/Login.jsx
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import { Checkbox, RaisedButton, Snackbar, TextField } from 'material-ui';
+import { darkBaseTheme, getMuiTheme, MuiThemeProvider } from 'material-ui/styles';
+import Qs from 'qs';
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+import { FormPanel, Header } from '../common';
+
+import AuthManager from './utils/AuthManager';
+
+const muiTheme = getMuiTheme(darkBaseTheme);
+
+/**
+ * Login page.
+ */
+export default class Login extends Component {
+    /**
+     * Constructor.
+     *
+     * @param {{}} props Props
+     */
+    constructor(props) {
+        super(props);
+        this.state = {
+            username: '',
+            password: '',
+            authenticated: false,
+            rememberMe: false,
+            referrer: window.contextPath,
+        };
+        this.authenticate = this.authenticate.bind(this);
+    }
+
+    /**
+     * Extract the referrer and check whether the user logged-in.
+     */
+    componentDidMount() {
+        // Extract referrer from the query string.
+        const queryString = this.props.location.search.replace(/^\?/, '');
+        const params = Qs.parse(queryString);
+        if (params.referrer) {
+            this.state.referrer = params.referrer;
+        }
+
+        // If the user already logged in set the state to redirect user to the referrer page.
+        if (AuthManager.isLoggedIn()) {
+            this.state.authenticated = true;
+        }
+    }
+
+    /**
+     * Call authenticate API and authenticate the user.
+     *
+     * @param {{}} e event
+     */
+    authenticate(e) {
+        e.preventDefault();
+        AuthManager
+            .authenticate(this.state.username, this.state.password, this.state.rememberMe)
+            .then(() => this.setState({ authenticated: true }))
+            .catch((error) => {
+                const errorMessage = error.response && error.response.status === 401 ?
+                    'Invalid username/password!' : 'Unknown error occurred!';
+                this.setState({
+                    username: '',
+                    password: '',
+                    error: errorMessage,
+                    showError: true,
+                });
+            });
+    }
+
+    /**
+     * Renders the login page.
+     *
+     * @return {XML} HTML content
+     */
+    render() {
+        // If the user is already authenticated redirect to referrer link.
+        if (this.state.authenticated) {
+            return (
+                <Redirect to={this.state.referrer} />
+            );
+        }
+
+        return (
+            <MuiThemeProvider muiTheme={muiTheme}>
+                <div>
+                    <Header title="Portal" hideUserSettings />
+                    <FormPanel title="Login" onSubmit={this.authenticate}>
+                        <TextField
+                            fullWidth
+                            floatingLabelText="Username"
+                            value={this.state.username}
+                            onChange={(e) => {
+                                this.setState({
+                                    username: e.target.value,
+                                    error: false,
+                                });
+                            }}
+                        />
+                        <br />
+                        <TextField
+                            fullWidth
+                            type="password"
+                            floatingLabelText="Password"
+                            value={this.state.password}
+                            onChange={(e) => {
+                                this.setState({
+                                    password: e.target.value,
+                                    error: false,
+                                });
+                            }}
+                        />
+                        <br />
+                        <Checkbox
+                            label="Remember Me"
+                            checked={this.state.rememberMe}
+                            onCheck={(e, checked) => {
+                                this.setState({
+                                    rememberMe: checked,
+                                });
+                            }}
+                        />
+                        <br />
+                        <RaisedButton
+                            primary
+                            type="submit"
+                            disabled={this.state.username === '' || this.state.password === ''}
+                            label="Login"
+                        />
+                    </FormPanel>
+                    <Snackbar
+                        message={this.state.error}
+                        open={this.state.showError}
+                        autoHideDuration="4000"
+                    />
+                </div>
+            </MuiThemeProvider>
+        );
+    }
+}

--- a/components/dashboards-web-component/src/auth/Logout.jsx
+++ b/components/dashboards-web-component/src/auth/Logout.jsx
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+
+import AuthManager from './utils/AuthManager';
+
+/**
+ * Logout.
+ */
+export default class Logout extends Component {
+    /**
+     * Renders logout component.
+     *
+     * @returns {XML} HTML content
+     */
+    render() {
+        AuthManager.logout();
+        return (
+            <Redirect to={{ pathname: `${window.contextPath}/login` }} />
+        );
+    }
+}

--- a/components/dashboards-web-component/src/auth/SecuredRouter.jsx
+++ b/components/dashboards-web-component/src/auth/SecuredRouter.jsx
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import Qs from 'qs';
+import React, { Component } from 'react';
+import { Redirect, Route, Switch } from 'react-router-dom';
+
+import DashboardCreatePage from '../designer/DashboardCreatePage';
+import DashboardDesigner from '../designer/DashboardDesigner';
+import DashboardSettings from '../designer/DashboardSettings';
+import DashboardListing from '../listing/DashboardListing';
+import DashboardView from '../viewer/DashboardView';
+import AuthManager from './utils/AuthManager';
+
+/**
+ * App context.
+ */
+const appContext = window.contextPath;
+
+/**
+ * Secured router (protects secured pages).
+ */
+export default class SecuredRouter extends Component {
+    /**
+     * Render routing.
+     *
+     * @return {XML} HTML content
+     */
+    render() {
+        // If the user is not logged in, redirect to the login page.
+        if (!AuthManager.isLoggedIn()) {
+            const params = Qs.stringify({ referrer: this.props.location.pathname });
+            return (
+                <Redirect to={{ pathname: `${appContext}/login`, search: params }} />
+            );
+        }
+
+        return (
+            <Switch>
+                {/* Dashboard listing a.k.a. landing page */}
+                <Route exact path={appContext} component={DashboardListing} />
+
+                {/* Create dashboard */}
+                <Route exact path={`${appContext}/create`} component={DashboardCreatePage} />
+
+                {/* Dashboard settings */}
+                <Route exact path={`${appContext}/settings/:id`} component={DashboardSettings} />
+
+                {/* Dashboard designer */}
+                <Route exact path='*/designer/:dashboardId' component={DashboardDesigner} />
+                <Route path='*/designer/:dashboardId/*' component={DashboardDesigner} />
+
+                {/* Dashboard view */}
+                <Route exact path='*/dashboards/:id' component={DashboardView} />
+                <Route path='*/dashboards/:id/*' component={DashboardView} />
+            </Switch>
+        );
+    }
+}

--- a/components/dashboards-web-component/src/auth/utils/AuthManager.jsx
+++ b/components/dashboards-web-component/src/auth/utils/AuthManager.jsx
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import AuthenticationAPI from '../../utils/apis/AuthenticationAPI';
+
+/**
+ * Name of the session cookie.
+ */
+const sessionUser = 'wso2dashboard_user';
+
+/**
+ * Authentication manager.
+ */
+export default class AuthManager {
+    /**
+     * Get user from the session cookie.
+     *
+     * @returns {{}|null} User object
+     */
+    static getUser() {
+        const buffer = AuthManager.getSessionCookie(sessionUser);
+        return buffer ? JSON.parse(buffer) : null;
+    }
+
+    /**
+     * Set user into a session cookie.
+     *
+     * @param {{}} user  User object
+     */
+    static setUser(user) {
+        AuthManager.setSessionCookie(sessionUser, JSON.stringify(user), 7 * 24 * 3600 * 1000);
+    }
+
+    /**
+     * Delete user from the session cookie.
+     */
+    static clearUser() {
+        AuthManager.deleteSessionCookie(sessionUser);
+    }
+
+    /**
+     * Check whether the user is logged in.
+     *
+     * @returns {boolean} Status
+     */
+    static isLoggedIn() {
+        return !!AuthManager.getUser();
+    }
+
+    /**
+     * Authenticate the user and set the user into the session.
+     *
+     * @param {string} username Username
+     * @param {string } password Password
+     * @param {boolean} rememberMe Remember me flag
+     * @returns {Promise} Promise
+     */
+    static authenticate(username, password, rememberMe) {
+        return new Promise((resolve, reject) => {
+            AuthenticationAPI
+                .login(username, password, rememberMe)
+                .then(() => {
+                    // TODO: Get user roles from the SCIM API.
+                    const roles = [];
+                    AuthManager.setUser({ username, rememberMe, roles });
+                    resolve();
+                })
+                .catch(error => reject(error));
+        });
+    }
+
+    /**
+     * Logout user by revoking tokens and clearing the session.
+     *
+     * @returns {Promise} Promise
+     */
+    static logout() {
+        return new Promise((resolve, reject) => {
+            AuthenticationAPI
+                .logout()
+                .then(() => {
+                    AuthManager.clearUser();
+                    resolve();
+                })
+                .catch(error => reject(error));
+        });
+    }
+
+    /**
+     * Set session cookie.
+     *
+     * @param {string} name Name of the cookie
+     * @param {string} value Value of the cookie
+     * @param {number} expiresIn Expires in
+     */
+    static setSessionCookie(name, value, expiresIn) {
+        let expires = '';
+        if (expiresIn) {
+            const d = new Date();
+            d.setTime(d.getTime() + expiresIn);
+            expires = `expires=${d.toUTCString()};`;
+        }
+        document.cookie = `${name}=${value};${expires}path=${window.contextPath}`;
+    }
+
+    /**
+     * Get session cookie by name.
+     *
+     * @param {string} name Name of the cookie
+     * @returns {string} Content
+     */
+    static getSessionCookie(name) {
+        name = `${name}=`;
+        const arr = document.cookie.split(';');
+        for (let i = 0; i < arr.length; i++) {
+            let c = arr[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Delete session cookie by name.
+     *
+     * @param {string} name Name of the cookie
+     */
+    static deleteSessionCookie(name) {
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/portal';
+    }
+}

--- a/components/dashboards-web-component/src/auth/utils/AuthManager.jsx
+++ b/components/dashboards-web-component/src/auth/utils/AuthManager.jsx
@@ -75,10 +75,10 @@ export default class AuthManager {
         return new Promise((resolve, reject) => {
             AuthenticationAPI
                 .login(username, password, rememberMe)
-                .then(() => {
+                .then((response) => {
                     // TODO: Get user roles from the SCIM API.
                     const roles = [];
-                    AuthManager.setUser({ username, rememberMe, roles });
+                    AuthManager.setUser({ username, rememberMe, roles, token: response.data.partialAccessToken });
                     resolve();
                 })
                 .catch(error => reject(error));
@@ -93,7 +93,7 @@ export default class AuthManager {
     static logout() {
         return new Promise((resolve, reject) => {
             AuthenticationAPI
-                .logout()
+                .logout(AuthManager.getUser().token)
                 .then(() => {
                     AuthManager.clearUser();
                     resolve();
@@ -107,7 +107,7 @@ export default class AuthManager {
      *
      * @param {string} name Name of the cookie
      * @param {string} value Value of the cookie
-     * @param {number} expiresIn Expires in
+     * @param {number} expiresIn Number of milliseconds to expire the cookie
      */
     static setSessionCookie(name, value, expiresIn) {
         let expires = '';

--- a/components/dashboards-web-component/src/common/components/Header.jsx
+++ b/components/dashboards-web-component/src/common/components/Header.jsx
@@ -17,29 +17,78 @@
  *
  */
 
-import React, {Component} from 'react';
-// Material UI
-import AppBar from 'material-ui/AppBar/AppBar';
-// CSS
-import './Header.css';
+import { AppBar, FlatButton, IconButton, IconMenu, MenuItem } from 'material-ui';
+import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import AuthManager from '../../auth/utils/AuthManager';
 
 import './Header.css';
 
+/**
+ * Header component.
+ */
 export default class Header extends Component {
+    /**
+     * Render right side header links.
+     *
+     * @returns {XML} HTML content
+     */
+    renderRightLinks() {
+        if (this.props.hideUserSettings) {
+            return <div />;
+        }
+
+        // If the user is not set show the login button. Else show account information.
+        const user = AuthManager.getUser();
+        if (!user) {
+            return (
+                <FlatButton
+                    label="Login"
+                    containerElement={<Link to={`${window.contextPath}/login?referrer=${window.location.pathname}`} />}
+                />
+            );
+        }
+
+        return (
+            <div className="header-right-btn-group">
+                <span className="acc-name">{user.username}</span>
+                <IconMenu
+                    iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
+                    targetOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+                    anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+                >
+                    <MenuItem
+                        primaryText="Logout"
+                        containerElement={<Link to={`${window.contextPath}/logout`} />}
+                    />
+                </IconMenu>
+            </div>
+        );
+    }
+
+    /**
+     * Render the component.
+     *
+     * @returns {XML} HTML content
+     */
     render() {
         return (
             <AppBar
                 title={this.props.title}
-                iconElementLeft={<i className="icon fw fw-wso2-logo header-icon"></i>}
+                iconElementLeft={<i className="icon fw fw-wso2-logo header-icon" />}
+                iconElementRight={this.renderRightLinks()}
             />
         );
     }
 }
 
 Header.propTypes = {
-    title: React.PropTypes.string
+    title: React.PropTypes.string,
+    hideUserSettings: React.PropTypes.bool,
 };
 
 Header.defaultProps = {
-    title: 'Portal'
+    title: 'Portal',
+    hideUserSettings: false,
 };

--- a/components/dashboards-web-component/src/utils/Constants.jsx
+++ b/components/dashboards-web-component/src/utils/Constants.jsx
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+/**
+ * HTTP status codes.
+ */
+const HttpStatus = {
+    OK: 200,
+    CONFLICT: 409,
+};
+
+/**
+ * Media types.
+ */
+const MediaType = {
+    APPLICATION_WWW_FORM_URLENCODED: 'application/x-www-form-urlencoded',
+    APPLICATION_JSON: 'application/json',
+};
+
+export { HttpStatus, MediaType };

--- a/components/dashboards-web-component/src/utils/apis/AuthenticationAPI.jsx
+++ b/components/dashboards-web-component/src/utils/apis/AuthenticationAPI.jsx
@@ -19,6 +19,7 @@
 
 import Axios from 'axios';
 import Qs from 'qs';
+import { MediaType } from '../Constants';
 
 // TODO: Get following configurations from the deployment.yaml at the backend.
 /**
@@ -29,7 +30,6 @@ const constants = {
     basePath: window.location.origin,
     grantTypePassword: 'password',
     appContext: window.contextPath.substr(1),
-    authorizationHeader: 'Basic YWRtaW46YWRtaW4=',
 };
 
 /**
@@ -46,7 +46,7 @@ export default class AuthenticationAPI {
             baseURL: constants.basePath,
             timeout: 2000,
         });
-        client.defaults.headers.post['Content-Type'] = 'application/json';
+        client.defaults.headers.post['Content-Type'] = MediaType.APPLICATION_JSON;
         return client;
     }
 
@@ -68,8 +68,7 @@ export default class AuthenticationAPI {
                 rememberMe,
             }), {
                 headers: {
-                    Authorization: constants.authorizationHeader,
-                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Content-Type': MediaType.APPLICATION_WWW_FORM_URLENCODED,
                 },
             });
     }
@@ -77,14 +76,15 @@ export default class AuthenticationAPI {
     /**
      * Logout user.
      *
+     * @param {string} token Partial access token
      * @return {AxiosPromise} Axios promise
      */
-    static logout() {
+    static logout(token) {
         return AuthenticationAPI
             .getHttpClient()
             .post(`/logout/${constants.appContext}`, null, {
                 headers: {
-                    Authorization: constants.authorizationHeader,
+                    Authorization: `Bearer ${token}`,
                 },
             });
     }

--- a/components/dashboards-web-component/src/utils/apis/AuthenticationAPI.jsx
+++ b/components/dashboards-web-component/src/utils/apis/AuthenticationAPI.jsx
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import Axios from 'axios';
+import Qs from 'qs';
+
+// TODO: Get following configurations from the deployment.yaml at the backend.
+/**
+ * Constants.
+ * @type {{}}
+ */
+const constants = {
+    basePath: window.location.origin,
+    grantTypePassword: 'password',
+    appContext: window.contextPath.substr(1),
+    authorizationHeader: 'Basic YWRtaW46YWRtaW4=',
+};
+
+/**
+ * Authentication API client.
+ */
+export default class AuthenticationAPI {
+    /**
+     * Get HTTP client.
+     *
+     * @return {AxiosInstance} Axios client
+     */
+    static getHttpClient() {
+        const client = Axios.create({
+            baseURL: constants.basePath,
+            timeout: 2000,
+        });
+        client.defaults.headers.post['Content-Type'] = 'application/json';
+        return client;
+    }
+
+    /**
+     * Login user.
+     *
+     * @param {string} username Username
+     * @param {string} password Password
+     * @param {boolean} rememberMe Remember me flag
+     * @return {AxiosPromise} Axios promise
+     */
+    static login(username, password, rememberMe = false) {
+        return AuthenticationAPI
+            .getHttpClient()
+            .post(`/login/${constants.appContext}`, Qs.stringify({
+                username,
+                password,
+                grantType: constants.grantTypePassword,
+                rememberMe,
+            }), {
+                headers: {
+                    Authorization: constants.authorizationHeader,
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+            });
+    }
+
+    /**
+     * Logout user.
+     *
+     * @return {AxiosPromise} Axios promise
+     */
+    static logout() {
+        return AuthenticationAPI
+            .getHttpClient()
+            .post(`/logout/${constants.appContext}`, null, {
+                headers: {
+                    Authorization: constants.authorizationHeader,
+                },
+            });
+    }
+}


### PR DESCRIPTION
## Purpose
Dashboard component currently doesn't have an authentication mechanism. This PR introduces basic authentication support (i.e. login, logout and session management) in dashboard component.

Resolves https://github.com/wso2/carbon-dashboards/issues/653

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above
This PR introduces login/logout pages which can be used to login to the portal app. Apart from that provides cookie based session management. 

## Approach
This implementation uses the existing common authentication API in carbon-analytics-common.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

_NOTE: Auth headers are currently hard-coded by need to be removed since there should not be a need to send auth headers for login and logout API calls._