### PR TITLE
Add more unit tests for org.wso2.carbon.dashboards.core component

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImplTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImplTest.java
@@ -67,7 +67,7 @@ public class DashboardMetadataProviderImplTest {
         DashboardMetadataProviderImpl dashboardMetadataProvider =
                 new DashboardMetadataProviderImpl(dao, new MockPermissionProvider());
 
-        Assertions.assertEquals(dashboardMetadataProvider.getAll().size(), 1);
+        Assertions.assertEquals(1, dashboardMetadataProvider.getAll().size());
         verify(dao).getAll();
     }
 

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/database/DashboardMetadataDaoTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/database/DashboardMetadataDaoTest.java
@@ -18,19 +18,30 @@
 
 package org.wso2.carbon.dashboards.core.internal.database;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.wso2.carbon.dashboards.core.bean.DashboardConfigurations;
+import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
+import org.wso2.carbon.dashboards.core.exception.DashboardException;
 
+import java.sql.Blob;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.stream.Stream;
+import javax.sql.DataSource;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test cases for {@link DashboardMetadataDao} class.
@@ -87,5 +98,180 @@ public class DashboardMetadataDaoTest {
         return Stream.of(
                 null, mock(Connection.class), exceptionThrowingConnection
         );
+    }
+
+    @Test
+    void testGetThrowException() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeQuery()).thenThrow(SQLException.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertThrows(DashboardException.class, () -> dao.get("foo"));
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    @Test
+    void testGetWhenNoResult() throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.next()).thenReturn(false);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertFalse(dao.get("foo").isPresent());
+        verify(preparedStatement).close();
+        verify(connection).close();
+        verify(resultSet).close();
+    }
+
+    @Test
+    void testGet() throws Exception {
+        Blob blob = mock(Blob.class);
+        when(blob.getBytes(anyLong(), anyInt())).thenReturn(new byte[]{});
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBlob(anyString())).thenReturn(blob);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertTrue(dao.get("foo").isPresent());
+        verify(preparedStatement).close();
+        verify(connection).close();
+        verify(resultSet).close();
+    }
+
+    @Test
+    void testGetAllThrowException() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeQuery()).thenThrow(SQLException.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertThrows(DashboardException.class, dao::getAll);
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    @Test
+    void testGetAll() throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.next()).thenReturn(true, false);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertEquals(1, dao.getAll().size());
+        verify(preparedStatement).close();
+        verify(connection).close();
+        verify(resultSet).close();
+    }
+
+    @Test
+    void testAddThrowException() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeUpdate()).thenThrow(SQLException.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertThrows(DashboardException.class, () -> dao.add(createDashboardMetadata()));
+        verify(connection).setAutoCommit(false);
+        verify(connection).rollback();
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    @Test
+    void testAdd() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        dao.add(createDashboardMetadata());
+        verify(connection).setAutoCommit(false);
+        verify(preparedStatement).executeUpdate();
+        verify(connection).commit();
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    @Test
+    void testUpdateThrowException() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeUpdate()).thenThrow(SQLException.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertThrows(DashboardException.class, () -> dao.update(createDashboardMetadata()));
+        verify(connection).setAutoCommit(false);
+        verify(connection).rollback();
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    @Test
+    void testUpdate() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        dao.update(createDashboardMetadata());
+        verify(connection).setAutoCommit(false);
+        verify(preparedStatement).executeUpdate();
+        verify(connection).commit();
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    @Test
+    void testDeleteThrowException() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.executeUpdate()).thenThrow(SQLException.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        Assertions.assertThrows(DashboardException.class, () -> dao.delete("foo"));
+        verify(connection).setAutoCommit(false);
+        verify(connection).rollback();
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    @Test
+    void testDelete() throws Exception {
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        Connection connection = createConnection(preparedStatement);
+        DashboardMetadataDao dao = createDao(connection);
+
+        dao.delete("foo");
+        verify(connection).setAutoCommit(false);
+        verify(preparedStatement).executeUpdate();
+        verify(connection).commit();
+        verify(preparedStatement).close();
+        verify(connection).close();
+    }
+
+    private static DashboardMetadataDao createDao(Connection mockedConnection) throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        when(dataSource.getConnection()).thenReturn(mockedConnection);
+        return new DashboardMetadataDao(dataSource, new QueryProvider(new DashboardConfigurations()));
+    }
+
+    private static Connection createConnection(PreparedStatement mockPreparedStatement) throws SQLException {
+        Connection connection = mock(Connection.class);
+        when(connection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(connection.createBlob()).thenReturn(mock(Blob.class));
+        return connection;
+    }
+
+    private static DashboardMetadata createDashboardMetadata() {
+        DashboardMetadata dashboardMetadata = new DashboardMetadata();
+        dashboardMetadata.setPages("{}");
+        return dashboardMetadata;
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/io/WidgetConfigurationReaderTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/io/WidgetConfigurationReaderTest.java
@@ -54,7 +54,7 @@ public class WidgetConfigurationReaderTest {
         Extension widget = new Extension(widgetName, EXTENSION_TYPE_WIDGETS, "src/test/resources/" + widgetName);
         WidgetMetaInfo widgetMetaInfo = WidgetConfigurationReader.getConfiguration(widget);
 
-        Assertions.assertEquals(widgetMetaInfo.getId(), widgetName);
-        Assertions.assertEquals(widgetMetaInfo.getName(), widgetName);
+        Assertions.assertEquals(widgetName, widgetMetaInfo.getId());
+        Assertions.assertEquals(widgetName, widgetMetaInfo.getName());
     }
 }


### PR DESCRIPTION
## Purpose
Currently `org.wso2.carbon.dashboards.core` component lacks unit tests.

## Goals
Add unit tests for `org.wso2.carbon.dashboards.core` component and improe code coverage.

## Approach
Added unit tests for 
- DashboardMetadataDao

Code coverage for `org.wso2.carbon.dashboards.core` component is 75%

## Automation tests
 - Unit tests 
    `org.wso2.carbon.dashboards.core`: 75%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Related PRs
#656 