### PR TITLE
Add message queue support for publisher widgets

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardDesigner.css
+++ b/components/dashboards-web-component/src/designer/DashboardDesigner.css
@@ -11,7 +11,6 @@
 
 .container {
     position: fixed;
-    top: 64px;
     right: 0;
     bottom: 0;
     left: 58px;

--- a/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
@@ -112,6 +112,7 @@ export default class DashboardDesigner extends Component {
         this.registerNotifier = this.registerNotifier.bind(this);
         this.updateDashboard = this.updateDashboard.bind(this);
         this.handleWidgetConfiguration = this.handleWidgetConfiguration.bind(this);
+        this.updatePageContent = this.updatePageContent.bind(this);
     }
 
     componentDidMount() {
@@ -145,7 +146,7 @@ export default class DashboardDesigner extends Component {
                                           window.location.href = window.contextPath + '/';
                                       }}/>
                         <RaisedButton label={<FormattedMessage id="save.button" defaultMessage="Save"/>} primary
-                                      onClick={this.updatePageContent.bind(this)}/>
+                                      onClick={this.updatePageContent}/>
                     </div>
 
                     {/* Left action bar */}

--- a/components/dashboards-web-component/src/utils/DashboardRenderingComponent.jsx
+++ b/components/dashboards-web-component/src/utils/DashboardRenderingComponent.jsx
@@ -79,7 +79,7 @@ class DashboardRenderingComponent extends React.Component {
         }
         widgetList.forEach(widget => {
             widgetList.add(widget);
-            widgetLoadingComponent.loadWidget(widget)
+            widgetLoadingComponent.loadWidget(widget);
         });
     }
 

--- a/samples/widgets/Publisher/src/Publisher.jsx
+++ b/samples/widgets/Publisher/src/Publisher.jsx
@@ -17,6 +17,7 @@
  *
  */
 
+import React, {Component} from 'react';
 import Widget from './Widget';
 
 class Publisher extends Widget {
@@ -40,6 +41,10 @@ class Publisher extends Widget {
         }
     }
 
+    componentDidMount() {
+        super.publish("Initial Message");
+    }
+
     getPublishedMsgsOutput() {
         const output = [];
         for (const key of this.publishedMsgSet.values()) {
@@ -59,7 +64,7 @@ class Publisher extends Widget {
         this.input.value = event.target.value;
     }
 
-    render() {
+    renderWidget() {
         return (
             <section style={{marginTop: 25}}>
                 <form onSubmit={this.publishMsg}>

--- a/samples/widgets/Publisher/src/Widget.jsx
+++ b/samples/widgets/Publisher/src/Widget.jsx
@@ -24,6 +24,20 @@ export default class Widget extends Component {
         super(props);
         this.getDashboardAPI = this.getDashboardAPI.bind(this);
         this.subscribe = this.subscribe.bind(this);
+        this.messageQueue = [];
+        this.publishQueuedMessages = this.publishQueuedMessages.bind(this);
+        this.props.glContainer.layoutManager.on("initialised", this.publishQueuedMessages);
+    }
+
+    /**
+     * This method publishers the queued messages in the widget. The messages are queued when the widget tried to
+     * publish before initializing the dashboard.
+     *
+     */
+    publishQueuedMessages() {
+        for (let messageId in this.messageQueue) {
+            this.publish(this.messageQueue[messageId])
+        }
     }
 
     /**
@@ -40,7 +54,11 @@ export default class Widget extends Component {
      */
     publish(message) {
         let publishedChannel = this.props.id;
-        this.props.glEventHub.emit(publishedChannel, message);
+        if (!this.props.glContainer.layoutManager.isInitialised) {
+            this.messageQueue.push(message)
+        } else {
+            this.props.glEventHub.emit(publishedChannel, message);
+        }
     }
 
     /**

--- a/samples/widgets/Subscriber/src/Subscriber.jsx
+++ b/samples/widgets/Subscriber/src/Subscriber.jsx
@@ -17,6 +17,7 @@
  *
  */
 
+import React, {Component} from 'react';
 import Widget from './Widget';
 
 class Subscriber extends Widget {
@@ -25,10 +26,10 @@ class Subscriber extends Widget {
         this.state = {receivedMsg: ''};
         this.set = new Set();
         this.clearMsgs = this.clearMsgs.bind(this);
-        this.setReceivedMsg = this.setReceivedMsg.bind(this)
+        this.setReceivedMsg = this.setReceivedMsg.bind(this);
     }
 
-    componentDidMount() {
+    componentWillMount() {
         super.subscribe(this.setReceivedMsg);
     }
 
@@ -54,7 +55,7 @@ class Subscriber extends Widget {
         this.set.clear();
     }
 
-    render() {
+    renderWidget() {
         return (<section style={{marginTop: 25}}><h4 style={{display: 'inline', marginRight: 10}}>Received Messages</h4>
             <input
                 type="button"

--- a/samples/widgets/Subscriber/src/Widget.jsx
+++ b/samples/widgets/Subscriber/src/Widget.jsx
@@ -24,6 +24,20 @@ export default class Widget extends Component {
         super(props);
         this.getDashboardAPI = this.getDashboardAPI.bind(this);
         this.subscribe = this.subscribe.bind(this);
+        this.messageQueue = [];
+        this.publishQueuedMessages = this.publishQueuedMessages.bind(this);
+        this.props.glContainer.layoutManager.on("initialised", this.publishQueuedMessages);
+    }
+
+    /**
+     * This method publishers the queued messages in the widget. The messages are queued when the widget tried to
+     * publish before initializing the dashboard.
+     *
+     */
+    publishQueuedMessages() {
+        for (let messageId in this.messageQueue) {
+            this.publish(this.messageQueue[messageId])
+        }
     }
 
     /**
@@ -40,7 +54,11 @@ export default class Widget extends Component {
      */
     publish(message) {
         let publishedChannel = this.props.id;
-        this.props.glEventHub.emit(publishedChannel, message);
+        if (!this.props.glContainer.layoutManager.isInitialised) {
+            this.messageQueue.push(message)
+        } else {
+            this.props.glEventHub.emit(publishedChannel, message);
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
> This PR introduces message queue implementation for publisher widgets. It resolves the message loss issue when the publisher widgets are loaded before subscriber widgets. Moreover this provides fixes for several bugs in carbon-dashboards alpha4 release.

## Goals
> Fix several bugs and message loss issue in pubsub communication.

## Approach
> There is an event loss if the publisher widget is rendered before the subscriber widget. Because publisher widgets start publishing and subscriber widgets are not ready to receive messages. So we have introduced a message queue in order to resolve this issue. We kept the messages in a queue until the dashboard is initialized. Once the dashboard is initialized, we flush all the messages in the message queue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)

Node - v6.11.2-linux-x64

Resolves #669 #668  #667 