### PR TITLE
Fix issues in dashboard listing page and marking landing page option.

### DIFF
--- a/components/dashboards-web-component/src/designer/components/PageEntry.jsx
+++ b/components/dashboards-web-component/src/designer/components/PageEntry.jsx
@@ -35,6 +35,10 @@ export default class PageEntry extends Component {
         this.updatePage = this.updatePage.bind(this);
     }
 
+    componentWillReceiveProps(nextProps){
+        this.setState({page:nextProps.page});
+    }
+
     render() {
         return (
             <Card onExpandChange={(expanded) => this.entryExpanded(expanded)}>

--- a/components/dashboards-web-component/src/designer/components/PagesPanel.jsx
+++ b/components/dashboards-web-component/src/designer/components/PagesPanel.jsx
@@ -56,9 +56,11 @@ export default class PagesPanel extends Component {
             <div style={this.getPanelStyles(this.props.visible)}>
                 <h3>Pages</h3>
                 <div style={{'text-align': 'center'}}>
-                    <RaisedButton label={<FormattedMessage id="create.page" defaultMessage="Create Page"/>} primary fullWidth icon={<AddCircleOutlineIcon/>}
+                    <RaisedButton label={<FormattedMessage id="create.page" defaultMessage="Create Page"/>} primary
+                                  fullWidth icon={<AddCircleOutlineIcon/>}
                                   onClick={this.addPage.bind(this)}/>
-                    <TextField hintText={<FormattedMessage id="search.hint.text" defaultMessage="Search..."/>} onChange={(e) => this.searchPages(e)}/>
+                    <TextField hintText={<FormattedMessage id="search.hint.text" defaultMessage="Search..."/>}
+                               onChange={(e) => this.searchPages(e)}/>
                 </div>
                 {
                     this.state.pages.map(p => {
@@ -193,9 +195,14 @@ export default class PagesPanel extends Component {
      * @param id
      */
     landingPageChanged(id) {
+        let pages = this.state.pages.map(page => {
+            page.id !== id ? page.landingPage = false : page.landingPage = true;
+            return page;
+        });
         if (this.props.onLandingPageChanged) {
             this.props.onLandingPageChanged(id);
         }
+        this.setState({pages: pages});
     }
 
     /**

--- a/components/dashboards-web-component/src/listing/DashboardThumbnail.jsx
+++ b/components/dashboards-web-component/src/listing/DashboardThumbnail.jsx
@@ -35,8 +35,7 @@ class DashboardThumbnail extends React.Component {
         this.handleClose = this.handleClose.bind(this);
         this.handleOpen = this.handleOpen.bind(this);
         this.state = {
-            deleteDashboardDialog: false,
-            thumbnailStyle: ""
+            deleteDashboardDialog: false
         };
     }
 
@@ -52,7 +51,7 @@ class DashboardThumbnail extends React.Component {
         let dashboardAPI = new DashboardAPI();
         dashboardAPI.deleteDashboardByID(this.props.dashboard.url);
         this.props.handleDelete();
-        this.setState({deleteDashboardDialog: false, thumbnailStyle: "dashboard-thumbnail-deleted"});
+        this.setState({deleteDashboardDialog: false});
     }
 
     render() {
@@ -83,7 +82,7 @@ class DashboardThumbnail extends React.Component {
         ];
 
         return (
-            <div className={this.state.thumbnailStyle}>
+            <div>
                 <Dialog
                     title={"Do you want to delete '" + this.props.dashboard.name + "' ?"}
                     actions={actionsButtons}


### PR DESCRIPTION
## Purpose
> This will fix the issue in dashboard listing page and marking landing page option. Let's consider a situation where there are multiple dashboards in the listing page and tries to delete one dashboard from it. Although we delete the dashboard, it is still showing on the listing page sometimes. If we change the landing page to a different page other than the home, it is not possible to change it back to Home page.

## Goals
> Fix the issues reported in GIT

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
>  java version "1.8.0_131"
    Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
    Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)

Node - v6.11.2-linux-x64
 

Resolves #671  #637 