### PR TITLE
Bump carbon-ui-server to v0.12.0

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/io/WidgetConfigurationReader.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/io/WidgetConfigurationReader.java
@@ -48,7 +48,7 @@ public class WidgetConfigurationReader {
      * @throws DashboardRuntimeException if cannot read configuration file or its is invalid
      */
     public static WidgetMetaInfo getConfiguration(Extension widget) throws DashboardRuntimeException {
-        Path widgetConfPath = Paths.get(widget.getPath(), FILE_NAME_WIDGET_CONFIGURATION);
+        Path widgetConfPath = Paths.get(widget.getLeastPriorityPath(), FILE_NAME_WIDGET_CONFIGURATION);
         try {
             String widgetConf = new String(Files.readAllBytes(widgetConfPath), StandardCharsets.UTF_8);
             return GSON.fromJson(widgetConf, WidgetMetaInfo.class);

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetInfoProviderImplTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetInfoProviderImplTest.java
@@ -84,7 +84,7 @@ public class WidgetInfoProviderImplTest {
     private static App createPortalApp() {
         Extension chartWidget = new Extension("LineChart", "widgets", "src/test/resources/LineChart");
         return new App("portal", "/portal", Collections.emptySortedSet(), Collections.singleton(chartWidget),
-                       Collections.emptySet(), null, null, null);
+                       Collections.emptySet(), Collections.emptySet(), null, null);
     }
 
     private static WidgetInfoProviderImpl createWidgetInfoProvider() {

--- a/pom.xml
+++ b/pom.xml
@@ -349,8 +349,8 @@
         <carbon.utils.version>2.0.2</carbon.utils.version>
 
         <!--UI Server-->
-        <carbon.ui.server.version>0.9.1</carbon.ui.server.version>
-        <carbon.ui.sever.version.range>[0.9.1, 1.0.0]</carbon.ui.sever.version.range>
+        <carbon.ui.server.version>0.12.0</carbon.ui.server.version>
+        <carbon.ui.sever.version.range>[0.12.0, 1.0.0]</carbon.ui.sever.version.range>
 
         <!--MSF4J-->
         <msf4j-core.version>2.3.0-m2</msf4j-core.version>


### PR DESCRIPTION
## Purpose
Bump carbon-ui-server to v0.12.0

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
