### PR TITLE
Disable pop out button in designer and enabling configuration buttons in viewer

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
@@ -67,7 +67,7 @@ const config = {
         popoutWholeStack: false,
         blockedPopoutsThrowError: true,
         closePopoutsOnUnload: true,
-        showPopoutIcon: true,
+        showPopoutIcon: false,
         showMaximiseIcon: true,
         responsive: true,
         responsiveMode: 'always',

--- a/components/dashboards-web-component/src/utils/DashboardRenderingComponent.jsx
+++ b/components/dashboards-web-component/src/utils/DashboardRenderingComponent.jsx
@@ -90,7 +90,7 @@ class DashboardRenderingComponent extends React.Component {
         });
         dashboardLayout.on("itemCreated", function (item) {
             if (item.isComponent && item.parent) {
-                item.parent.header.controlsContainer.children()[4].style.display = "list-item";
+                item.parent.header.controlsContainer.children()[3].style.display = "list-item";
                 that.isSubscriber(item.config) ? "" : item.parent.header.controlsContainer.children()[0].remove();
             }
             else if (item.header) {

--- a/components/dashboards-web-component/src/viewer/DashboardView.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardView.jsx
@@ -53,7 +53,7 @@ const lightMuiTheme = getMuiTheme({
 
 let config = {
     settings: {
-        hasHeaders: false,
+        hasHeaders: true,
         constrainDragToContainer: false,
         reorderEnabled: false,
         selectionEnabled: false,
@@ -61,7 +61,7 @@ let config = {
         blockedPopoutsThrowError: true,
         closePopoutsOnUnload: true,
         showPopoutIcon: false,
-        showMaximiseIcon: false,
+        showMaximiseIcon: true,
         responsive: true,
         isClosable: false,
         responsiveMode: 'always',


### PR DESCRIPTION

## Purpose
Resolves https://github.com/wso2/product-sp/issues/84

## Approach
Pop out button config has been disabled globally from the dashboard config so that it will not be visible to any of the widgets. Also configuration buttons are enabled for the designer mode.
