### PR TITLE
 Use widgetId to render the widgets

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
@@ -74,8 +74,6 @@ const config = {
         showCloseIcon: true,
     },
     dimensions: {
-        minItemWidth: 400,
-        minItemHeight: 400,
         headerHeight: 37
     },
     content: [],

--- a/components/dashboards-web-component/src/designer/components/WidgetsList.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetsList.jsx
@@ -129,11 +129,11 @@ export default  class WidgetsList extends React.Component {
                 newItemConfig = {
                     title: widget.name,
                     type: 'react-component',
-                    component: widget.name,
+                    component: widget.id,
                     props: {id: DashboardUtils.generateguid(), configs: widget.configs}
                 };
-                widgetListDragSources.set(widget.name, widgetLoadingComponent.createDragSource(document.getElementById(widget.name), newItemConfig));
-                widgetLoadingComponent.loadWidget(widget.name);
+                widgetListDragSources.set(widget.id, widgetLoadingComponent.createDragSource(document.getElementById(widget.id), newItemConfig));
+                widgetLoadingComponent.loadWidget(widget.id);
             });
             if (initDashboardFlag || isPreviouslyInitialized) {
                 widgetLoadingComponent.initializeDashboard();
@@ -153,7 +153,7 @@ export default  class WidgetsList extends React.Component {
                 <Divider/>
                 {
                     this.state.widgets.map(widget => {
-                        return <WidgetListThumbnail widgetID={widget.name} isDisplayed={this.isDisplayed(widget.name)}
+                        return <WidgetListThumbnail widgetID={widget.id} isDisplayed={this.isDisplayed(widget.name)}
                                                     data={this.state.widgetList} widgetName={widget.name}/>;
                     })
                 }

--- a/components/dashboards-web-component/src/viewer/DashboardView.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardView.jsx
@@ -68,7 +68,6 @@ let config = {
         showCloseIcon: false,
     },
     dimensions: {
-        minItemWidth: 400,
         headerHeight: 37
     },
     isClosable: false,


### PR DESCRIPTION
## Purpose
> This PR will use widgetID instead of widget name to render widgets. Moreover, this will remove the minimum width and height introduced in golden layout level.

## Goals
> use widgetID instead of widget name to render widget
> remove the minimum width and height introduced in golden layout level