### PR TITLE
Add loading spinner in dashboard view

### DIFF
--- a/components/dashboards-web-component/public/css/dashboard.css
+++ b/components/dashboards-web-component/public/css/dashboard.css
@@ -48,11 +48,13 @@ a {
     box-sizing: border-box;
     height: calc(100vh - 64px);
     font-family: Roboto, sans-serif;
+    position: relative;
 }
 
 .dashboard-view-full-width {
     margin-left: 0;
     height: 88vh;
+    position: relative;
 }
 
 .pages-navigation-panel {
@@ -550,4 +552,21 @@ a {
 
 .sample-rev-table .currency {
     font-size: 22px;
+}
+
+/* Dashboard loading spinner */
+.dashboard-spinner {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    text-align: center;
+    padding-top: 100px;
+}
+
+.dashboard-spinner .loading-label {
+    color: #fff;
+    text-align: center;
+    padding-top: 20px;
 }

--- a/components/dashboards-web-component/src/utils/DashboardRenderingComponent.jsx
+++ b/components/dashboards-web-component/src/utils/DashboardRenderingComponent.jsx
@@ -68,7 +68,10 @@ class DashboardRenderingComponent extends React.Component {
             document.getElementById('dashboard-view'), this.props.onContentModified);
         let that = this;
         dashboardLayout.on("initialised", function () {
-            that.wirePubSubWidgets(dashboardLayout.toConfig().content)
+            that.wirePubSubWidgets(dashboardLayout.toConfig().content);
+            if (that.props.onInitialized) {
+                that.props.onInitialized();
+            }
         });
 
         if (this.props.designer) {

--- a/components/dashboards-web-component/src/viewer/DashboardView.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardView.jsx
@@ -23,6 +23,7 @@ import AppBar from 'material-ui/AppBar/AppBar';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import Drawer from 'material-ui/Drawer';
+import CircularProgress from 'material-ui/CircularProgress';
 
 import DashboardRenderingComponent from '../utils/DashboardRenderingComponent';
 import PagesNavigationPanel from '../designer/components/PagesNavigationPanel';
@@ -84,7 +85,8 @@ class DashboardView extends React.Component {
             dashboardContent: [],
             open: true,
             contentClass: "content-drawer-opened",
-            muiTheme: darkMuiTheme
+            muiTheme: darkMuiTheme,
+            requestHideLoading: false,
         };
         this.togglePagesNavPanel = this.togglePagesNavPanel.bind(this);
         this.setDashboardProperties = this.setDashboardProperties.bind(this);
@@ -134,6 +136,12 @@ class DashboardView extends React.Component {
     }
 
     render() {
+        let showLoading = true;
+        if (this.state.requestHideLoading) {
+            showLoading = false;
+            this.state.requestHideLoading = false;
+        }
+
         return (
             <MuiThemeProvider muiTheme={this.state.muiTheme}>
                 <div>
@@ -152,13 +160,28 @@ class DashboardView extends React.Component {
                             onLeftIconButtonTouchTap={this.handleToggle}
                             className="app-bar"
                         />
-                        <div id="dashboard-view" className={this.state.dashboardViewCSS}></div>
-                        <DashboardRenderingComponent config={config} ref={(c) => {
-                            this.dashboardRenderingComponent = c;
-                        }}
-                                                     dashboardContent={new DashboardUtils().getDashboardByPageId(this.props.match.params[1],
-                            this.state.dashboardContent, this.state.landingPage)}/>
-
+                        <div id="dashboard-view" className={this.state.dashboardViewCSS}>
+                            <div
+                                className="dashboard-spinner"
+                                style={showLoading ? {} : { display: 'none' }}
+                            >
+                                <CircularProgress size={150} thickness={10} />
+                                <div
+                                    className="loading-label"
+                                    style={{ color: this.state.muiTheme.palette.textColor }}>
+                                    Loading...
+                                </div>
+                            </div>
+                        </div>
+                        <DashboardRenderingComponent
+                            config={config}
+                            ref={(c) => {
+                                this.dashboardRenderingComponent = c;
+                            }}
+                            dashboardContent={new DashboardUtils().getDashboardByPageId(this.props.match.params[1],
+                                this.state.dashboardContent, this.state.landingPage)}
+                            onInitialized={() => this.setState({ requestHideLoading: true })}
+                        />
                     </div>
                 </div>
             </MuiThemeProvider>


### PR DESCRIPTION
## Purpose
This PR introduces a loading spinner in dashboard view page. The spinner will be displayed while the dashboard is loaded and renders at the background.

Relates to https://github.com/wso2/carbon-dashboards/issues/722

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes