### PR TITLE
Fix issue in referrer path

### DIFF
--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -9,7 +9,7 @@
     "dev": "webpack-dev-server --hot --inline --progress --history-api-fallback",
     "lint": "eslint . --ext .jsx --ext .js",
     "build": "webpack -p",
-    "deploy": "cp ./dist/bundle.js $DS_HOME/deployment/web-ui-apps/portal/public/js/"
+    "deploy": "cp ./dist/bundle.js $DS_HOME/wso2/dashboard/deployment/web-ui-apps/portal/public/js/"
   },
   "repository": {
     "type": "git",

--- a/components/dashboards-web-component/src/auth/SecuredRouter.jsx
+++ b/components/dashboards-web-component/src/auth/SecuredRouter.jsx
@@ -46,7 +46,13 @@ export default class SecuredRouter extends Component {
     render() {
         // If the user is not logged in, redirect to the login page.
         if (!AuthManager.isLoggedIn()) {
-            const params = Qs.stringify({ referrer: this.props.location.pathname });
+            let referrer = this.props.location.pathname;
+            const arr = referrer.split('');
+            if (arr[arr.length - 1] !== '/') {
+                referrer += '/';
+            }
+
+            const params = Qs.stringify({ referrer });
             return (
                 <Redirect to={{ pathname: `${appContext}/login`, search: params }} />
             );


### PR DESCRIPTION
## Purpose
Once the user login again after logout, `/portal` context is dropping from the URLs which redirects user to invalid URLs. This PR fixes that issue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes