### PR TITLE
Bumped React-VizGrammar version to v0.6.6 in UniversalWidget

### DIFF
--- a/samples/widgets/UniversalWidget/package.json
+++ b/samples/widgets/UniversalWidget/package.json
@@ -7,7 +7,7 @@
         "axios": "^0.17.1",
         "react": "^16.2.0",
         "react-dom": "^16.2.0",
-        "react-vizgrammar": "^0.6.5",
+        "react-vizgrammar": "0.6.6",
         "rimraf": "^2.6.2"
     },
     "scripts": {


### PR DESCRIPTION
## Purpose
> Bumped React-VizGrammar version to v0.6.6 in UniversalWidget

## Test environment
NPM v5.3.0, Node.JS v8.5.0
