### PR TITLE
Bump Carbon UI Server version to 0.17.0

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
 
+        <!--UI Server-->
+        <dependency>
+            <groupId>org.wso2.carbon.uis</groupId>
+            <artifactId>org.wso2.carbon.uis</artifactId>
+        </dependency>
+
         <!--OSGi-->
         <dependency>
             <groupId>org.osgi</groupId>
@@ -79,7 +85,7 @@
             <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
         </dependency>
 
@@ -100,16 +106,18 @@
             org.wso2.carbon.dashboards.core.*; version="${carbon.dashboards.version}",
             org.wso2.msf4j.*; version="${msf4j-core.version.range}",
             javax.ws.rs.*; version="${javax.ws.rs.version.range}",
+            org.wso2.carbon.uis.api.*; version="${carbon.ui.sever.version.range}",
+            org.wso2.carbon.uis.spi.*; version="${carbon.ui.sever.version.range}",
             org.osgi.framework; version="${org.osgi.framework.version.range}",
             org.osgi.framework.wiring; version="${org.osgi.framework.wiring.version.range}",
             org.osgi.service.component.annotations.*; version="${org.osgi.service.component.annotations.version.range}",
             org.slf4j.*; version="${slf4j.version.range}",
             org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
-            org.wso2.carbon.analytics.msf4j.interceptor.common.*; version="${carbon.analytics-common.version.range}",
+            org.wso2.carbon.analytics.msf4j.interceptor.common.*; version="${carbon.analytics.version.range}",
             org.owasp.encoder.*; version="${owasp.encoder.version.range}"
         </import.package>
         <carbon.component>
-            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="2"
+            osgi.service; objectClass="org.wso2.carbon.uis.spi.RestApiProvider"
         </carbon.component>
     </properties>
 

--- a/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/pom.xml
@@ -55,6 +55,21 @@
             <artifactId>org.wso2.carbon.uis</artifactId>
         </dependency>
 
+        <!--Analytics-->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics</groupId>
+            <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
+        </dependency>
+        <!-- Analytics common -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
+        </dependency>
+
         <!--OSGi-->
         <dependency>
             <groupId>org.osgi</groupId>
@@ -73,20 +88,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-
-        <!-- Analytics common -->
-        <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.analytics</groupId>
-            <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
         </dependency>
 
         <!-- OWASP -->
@@ -108,12 +109,12 @@
             javax.ws.rs.*; version="${javax.ws.rs.version.range}",
             org.wso2.carbon.uis.api.*; version="${carbon.ui.sever.version.range}",
             org.wso2.carbon.uis.spi.*; version="${carbon.ui.sever.version.range}",
+            org.wso2.carbon.analytics.msf4j.interceptor.common.*; version="${carbon.analytics.version.range}",
+            org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
             org.osgi.framework; version="${org.osgi.framework.version.range}",
             org.osgi.framework.wiring; version="${org.osgi.framework.wiring.version.range}",
             org.osgi.service.component.annotations.*; version="${org.osgi.service.component.annotations.version.range}",
             org.slf4j.*; version="${slf4j.version.range}",
-            org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
-            org.wso2.carbon.analytics.msf4j.interceptor.common.*; version="${carbon.analytics.version.range}",
             org.owasp.encoder.*; version="${owasp.encoder.version.range}"
         </import.package>
         <carbon.component>

--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApiProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApiProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.api.internal;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.dashboards.core.DashboardMetadataProvider;
+import org.wso2.carbon.dashboards.core.WidgetMetadataProvider;
+import org.wso2.carbon.uis.api.App;
+import org.wso2.carbon.uis.spi.RestApiProvider;
+import org.wso2.msf4j.Microservice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provider that supplies Microservices for the {@link #DASHBOARD_PORTAL_APP_NAME} web app.
+ *
+ * @since 4.0.0
+ */
+@Component(service = RestApiProvider.class,
+           immediate = true)
+public class DashboardRestApiProvider implements RestApiProvider {
+
+    public static final String DASHBOARD_PORTAL_APP_NAME = "portal";
+    private static final Logger LOGGER = LoggerFactory.getLogger(DashboardRestApiProvider.class);
+
+    private DashboardMetadataProvider dashboardDataProvider;
+    private WidgetMetadataProvider widgetMetadataProvider;
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        LOGGER.debug("{} activated.", this.getClass().getName());
+    }
+
+    @Deactivate
+    protected void deactivate(BundleContext bundleContext) {
+        LOGGER.debug("{} deactivated.", this.getClass().getName());
+    }
+
+    @Reference(service = DashboardMetadataProvider.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetDashboardMetadataProvider")
+    protected void setDashboardMetadataProvider(DashboardMetadataProvider dashboardDataProvider) {
+        this.dashboardDataProvider = dashboardDataProvider;
+        LOGGER.debug("DashboardMetadataProvider '{}' registered.", dashboardDataProvider.getClass().getName());
+    }
+
+    protected void unsetDashboardMetadataProvider(DashboardMetadataProvider dashboardDataProvider) {
+        this.dashboardDataProvider = null;
+        LOGGER.debug("DashboardMetadataProvider '{}' unregistered.", dashboardDataProvider.getClass().getName());
+    }
+
+    @Reference(service = WidgetMetadataProvider.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetWidgetMetadataProvider")
+    protected void setWidgetMetadataProvider(WidgetMetadataProvider widgetMetadataProvider) {
+        this.widgetMetadataProvider = widgetMetadataProvider;
+        LOGGER.debug("WidgetMetadataProvider '{}' registered.", widgetMetadataProvider.getClass().getName());
+    }
+
+    protected void unsetWidgetMetadataProvider(WidgetMetadataProvider widgetMetadataProvider) {
+        this.widgetMetadataProvider = null;
+        LOGGER.debug("WidgetMetadataProvider '{}' registered.", widgetMetadataProvider.getClass().getName());
+    }
+
+    @Override
+    public String getAppName() {
+        return DASHBOARD_PORTAL_APP_NAME;
+    }
+
+    @Override
+    public Map<String, Microservice> getMicroservices(App app) {
+        Map<String, Microservice> microservices = new HashMap<>(2);
+        microservices.put(DashboardRestApi.API_CONTEXT_PATH, new DashboardRestApi(dashboardDataProvider));
+        widgetMetadataProvider.setDashboardApp(app);
+        microservices.put(WidgetRestApi.API_CONTEXT_PATH, new WidgetRestApi(widgetMetadataProvider));
+        return microservices;
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/WidgetRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/WidgetRestApi.java
@@ -18,13 +18,6 @@
 
 package org.wso2.carbon.dashboards.api.internal;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.owasp.encoder.Encode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,37 +48,21 @@ import static javax.ws.rs.core.Response.Status.OK;
  *
  * @since 4.0.0
  */
-@Component(name = "org.wso2.carbon.dashboards.api.WidgetApi",
-        service = Microservice.class,
-        immediate = true)
-@Path("/portal/apis/widgets")
 @RequestInterceptor(AuthenticationInterceptor.class)
 public class WidgetRestApi implements Microservice {
 
+    public static final String API_CONTEXT_PATH = "/apis/widgets";
     private static final Logger LOGGER = LoggerFactory.getLogger(WidgetRestApi.class);
 
-    private WidgetMetadataProvider widgetMetadataProvider;
+    private final WidgetMetadataProvider widgetMetadataProvider;
 
-    @Activate
-    protected void activate(BundleContext bundleContext) {
-        LOGGER.debug("{} activated.", this.getClass().getName());
-    }
-
-    @Deactivate
-    protected void deactivate(BundleContext bundleContext) {
-        LOGGER.debug("{} deactivated.", this.getClass().getName());
-    }
-
-    @Reference(service = WidgetMetadataProvider.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetWidgetInfoProvider")
-    protected void setWidgetMetadataProvider(WidgetMetadataProvider widgetMetadataProvider) {
+    /**
+     * Creates a new widget REST API.
+     *
+     * @param widgetMetadataProvider metadata provider for widgets
+     */
+    public WidgetRestApi(WidgetMetadataProvider widgetMetadataProvider) {
         this.widgetMetadataProvider = widgetMetadataProvider;
-    }
-
-    protected void unsetWidgetInfoProvider(WidgetMetadataProvider widgetMetadataProvider) {
-        this.widgetMetadataProvider = null;
     }
 
     /**
@@ -121,7 +98,7 @@ public class WidgetRestApi implements Microservice {
                     .orElse(Response.status(NOT_FOUND).entity("Cannot find widget '" + widgetId + "'.").build());
         } catch (DashboardException e) {
             LOGGER.error("An error occurred when retrieving configuration of widget '{}'.",
-                    getEncodedString(widgetId), e);
+                         getEncodedString(widgetId), e);
             return serverErrorResponse("Cannot retrieve configuration of widget '" + widgetId + "'.");
         }
     }
@@ -166,7 +143,7 @@ public class WidgetRestApi implements Microservice {
             }
         } catch (DashboardException e) {
             LOGGER.error("An error occurred when validating the widget name: " +
-                    getEncodedString(widgetName) + ".", e);
+                         getEncodedString(widgetName) + ".", e);
             return Response.serverError()
                     .entity("An error occurred when validating the widget name: " + widgetName + ".").build();
         }
@@ -210,7 +187,7 @@ public class WidgetRestApi implements Microservice {
             return Response.status(CREATED).build();
         } catch (DashboardException e) {
             LOGGER.error("An error occurred when creating a new gadget from {} data.",
-                    getEncodedString(generatedWidgetConfigs.toString()), e);
+                         getEncodedString(generatedWidgetConfigs.toString()), e);
             return Response.serverError()
                     .entity("Cannot create a new gadget from '" + generatedWidgetConfigs + "'.").build();
         }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
@@ -51,6 +51,16 @@
             <artifactId>org.wso2.carbon.uis</artifactId>
         </dependency>
 
+        <!-- Analytics common -->
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
+        </dependency>
+
         <!--OSGi-->
         <dependency>
             <groupId>org.osgi</groupId>
@@ -96,16 +106,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-
-        <!-- Permission provider -->
-        <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -130,6 +130,8 @@
             org.wso2.carbon.config.*; version="${carbon.config.version.range}",
             org.wso2.carbon.uis.api.*; version="${carbon.ui.sever.version.range}",
             org.wso2.carbon.uis.spi.*; version="${carbon.ui.sever.version.range}",
+            org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
+            org.wso2.carbon.analytics.idp.client.*; version="${carbon.analytics-common.version.range}",
             org.osgi.framework; version="${org.osgi.framework.version.range}",
             org.osgi.framework.wiring; version="${org.osgi.framework.wiring.version.range}",
             org.osgi.service.component.annotations.*; version="${org.osgi.service.component.annotations.version.range}",
@@ -137,8 +139,6 @@
             com.google.gson.*; version="${gson.version.range}",
             org.yaml.snakeyaml.*; version="${org.yaml.version.range}",
             javax.ws.rs.*; version="${javax.ws.rs.version.range}",
-            org.wso2.carbon.analytics.permissions.*; version="${carbon.analytics-common.version.range}",
-            org.wso2.carbon.analytics.idp.client.*; version="${carbon.analytics-common.version.range}"
         </import.package>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
     </properties>

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.dashboards.core;
 import org.wso2.carbon.dashboards.core.bean.widget.GeneratedWidgetConfigs;
 import org.wso2.carbon.dashboards.core.bean.widget.WidgetMetaInfo;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
+import org.wso2.carbon.uis.api.App;
 
 import java.util.Optional;
 import java.util.Set;
@@ -49,7 +50,6 @@ public interface WidgetMetadataProvider {
      */
     void addGeneratedWidgetConfigs(GeneratedWidgetConfigs generatedWidgetConfigs) throws DashboardException;
 
-
     /**
      * Returns configurations of al available widgets.
      *
@@ -74,4 +74,17 @@ public interface WidgetMetadataProvider {
      */
     boolean isWidgetPresent(String widgetName) throws DashboardException;
 
+    /**
+     * Sets the dashboard portal app to this provider.
+     *
+     * @param dashboardApp dashboard portal app
+     */
+    void setDashboardApp(App dashboardApp);
+
+    /**
+     * Returns the dashboard portal app of this provider.
+     *
+     * @return dashboard portal app
+     */
+    App getDashboardApp();
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImplTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImplTest.java
@@ -21,18 +21,10 @@ package org.wso2.carbon.dashboards.core.internal;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
-import org.wso2.carbon.dashboards.core.exception.DashboardRuntimeException;
 import org.wso2.carbon.uis.api.App;
 import org.wso2.carbon.uis.api.Extension;
-import org.wso2.carbon.uis.spi.Server;
 
 import java.util.Collections;
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test cases for {@link WidgetMetadataProviderImpl} class.
@@ -42,14 +34,10 @@ import static org.mockito.Mockito.when;
 public class WidgetMetadataProviderImplTest {
 
     @Test
-    void testGetWidgetConfigurationWithoutPortalApp() {
-        Server server = mock(Server.class);
-        when(server.getApp(anyString())).thenReturn(Optional.empty());
+    void testSetDashboardApp() {
         WidgetMetadataProviderImpl widgetInfoProvider = new WidgetMetadataProviderImpl();
-        widgetInfoProvider.setCarbonUiServer(server);
-
-        Assertions.assertThrows(DashboardRuntimeException.class,
-                                () -> widgetInfoProvider.getWidgetConfiguration("foo"));
+        Assertions.assertThrows(NullPointerException.class,
+                                () -> widgetInfoProvider.setDashboardApp(null));
     }
 
     @Test
@@ -74,11 +62,8 @@ public class WidgetMetadataProviderImplTest {
 
     @Test
     void testOthers() {
-        Server server = mock(Server.class);
         WidgetMetadataProviderImpl widgetInfoProvider = new WidgetMetadataProviderImpl();
         widgetInfoProvider.activate(null);
-        widgetInfoProvider.setCarbonUiServer(server);
-        widgetInfoProvider.unsetCarbonUiServer(server);
         widgetInfoProvider.deactivate(null);
     }
 
@@ -90,10 +75,8 @@ public class WidgetMetadataProviderImplTest {
 
     private static WidgetMetadataProviderImpl createWidgetInfoProvider() {
         App portalApp = createPortalApp();
-        Server server = mock(Server.class);
-        when(server.getApp(eq(portalApp.getName()))).thenReturn(Optional.of(portalApp));
         WidgetMetadataProviderImpl widgetInfoProvider = new WidgetMetadataProviderImpl();
-        widgetInfoProvider.setCarbonUiServer(server);
+        widgetInfoProvider.setDashboardApp(portalApp);
         return widgetInfoProvider;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -389,9 +389,9 @@
                 <version>${carbon.analytics-common.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <groupId>org.wso2.carbon.analytics</groupId>
                 <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
-                <version>${carbon.analytics-common.version}</version>
+                <version>${carbon.analytics.version}</version>
             </dependency>
 
             <!-- OWASP -->
@@ -406,8 +406,11 @@
     <properties>
         <carbon.dashboards.version>4.0.0.beta3-SNAPSHOT</carbon.dashboards.version>
 
-        <carbon.analytics-common.version>6.0.32</carbon.analytics-common.version>
-        <carbon.analytics-common.version.range>[6.0.20, 7.0.0)</carbon.analytics-common.version.range>
+        <!--Analytics-->
+        <carbon.analytics-common.version>6.0.36</carbon.analytics-common.version>
+        <carbon.analytics-common.version.range>[6.0.36, 7.0.0)</carbon.analytics-common.version.range>
+        <carbon.analytics.version>2.0.197</carbon.analytics.version>
+        <carbon.analytics.version.range>[2.0.197, 3.0.0)</carbon.analytics.version.range>
 
         <!-- Datasource -->
         <carbon.datasource.core.version>1.1.2</carbon.datasource.core.version>
@@ -421,8 +424,8 @@
         <carbon.utils.version>2.0.2</carbon.utils.version>
 
         <!--UI Server-->
-        <carbon.ui.server.version>0.14.1</carbon.ui.server.version>
-        <carbon.ui.sever.version.range>[0.14.1, 1.0.0]</carbon.ui.sever.version.range>
+        <carbon.ui.server.version>0.17.0</carbon.ui.server.version>
+        <carbon.ui.sever.version.range>[0.17.0, 1.0.0]</carbon.ui.sever.version.range>
 
         <!--MSF4J-->
         <msf4j-core.version>2.5.0-beta</msf4j-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,24 @@
                 <type>zip</type>
             </dependency>
 
+            <!--Analytics-->
+            <dependency>
+                <groupId>org.wso2.carbon.analytics</groupId>
+                <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
+                <version>${carbon.analytics.version}</version>
+            </dependency>
+            <!-- Analytics common -->
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+
             <!--OSGi-->
             <dependency>
                 <groupId>org.osgi</groupId>
@@ -225,6 +243,12 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${org.snakeyaml.version}</version>
+            </dependency>
+            <!-- OWASP -->
+            <dependency>
+                <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+                <artifactId>encoder</artifactId>
+                <version>${owasp.encoder.version}</version>
             </dependency>
 
             <!--Samples-->
@@ -376,41 +400,11 @@
                 <version>${mockito.core.version}</version>
                 <scope>test</scope>
             </dependency>
-
-            <!-- Analytics common -->
-            <dependency>
-                <groupId>org.wso2.carbon.analytics-common</groupId>
-                <artifactId>org.wso2.carbon.analytics.idp.client</artifactId>
-                <version>${carbon.analytics-common.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.analytics-common</groupId>
-                <artifactId>org.wso2.carbon.analytics.permissions</artifactId>
-                <version>${carbon.analytics-common.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.analytics</groupId>
-                <artifactId>org.wso2.carbon.analytics.msf4j.interceptor.common</artifactId>
-                <version>${carbon.analytics.version}</version>
-            </dependency>
-
-            <!-- OWASP -->
-            <dependency>
-                <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-                <artifactId>encoder</artifactId>
-                <version>${owasp.encoder.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <properties>
         <carbon.dashboards.version>4.0.0.beta3-SNAPSHOT</carbon.dashboards.version>
-
-        <!--Analytics-->
-        <carbon.analytics-common.version>6.0.36</carbon.analytics-common.version>
-        <carbon.analytics-common.version.range>[6.0.36, 7.0.0)</carbon.analytics-common.version.range>
-        <carbon.analytics.version>2.0.197</carbon.analytics.version>
-        <carbon.analytics.version.range>[2.0.197, 3.0.0)</carbon.analytics.version.range>
 
         <!-- Datasource -->
         <carbon.datasource.core.version>1.1.2</carbon.datasource.core.version>
@@ -445,6 +439,13 @@
         <carbon.jndi.version>1.0.3</carbon.jndi.version>
         <carbon.datasources.version>1.1.2</carbon.datasources.version>
 
+        <!--Analytics-->
+        <carbon.analytics.version>2.0.197</carbon.analytics.version>
+        <carbon.analytics.version.range>[2.0.197, 3.0.0)</carbon.analytics.version.range>
+        <!--Analytics common-->
+        <carbon.analytics-common.version>6.0.36</carbon.analytics-common.version>
+        <carbon.analytics-common.version.range>[6.0.36, 7.0.0)</carbon.analytics-common.version.range>
+
         <!--OSGi-->
         <org.osgi.api.version>6.0.0</org.osgi.api.version>
         <org.wso2.eclipse.osgi.version>3.4.0.v20140312-2051</org.wso2.eclipse.osgi.version>
@@ -466,7 +467,6 @@
         <!--Snake YAML-->
         <org.snakeyaml.version>1.17</org.snakeyaml.version>
         <org.yaml.version.range>[1.17.0, 2.0.0)</org.yaml.version.range>
-
         <!-- OWASP -->
         <owasp.encoder.version>1.2.0.wso2v2</owasp.encoder.version>
         <owasp.encoder.version.range>[1.2.0, 1.3.0)</owasp.encoder.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -134,31 +134,6 @@
                 <version>${javax.websocket.version}</version>
             </dependency>
 
-            <!--Transport-->
-            <dependency>
-                <groupId>org.wso2.carbon.messaging</groupId>
-                <artifactId>org.wso2.carbon.messaging</artifactId>
-                <version>${carbon.messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.messaging</groupId>
-                <artifactId>org.wso2.carbon.messaging.feature</artifactId>
-                <version>${carbon.messaging.version}</version>
-                <type>zip</type>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.transport</groupId>
-                <artifactId>org.wso2.carbon.transport.http.netty.feature</artifactId>
-                <version>${carbon.transport.version}</version>
-                <type>zip</type>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.transport</groupId>
-                <artifactId>org.wso2.carbon.connector.framework.feature</artifactId>
-                <version>${carbon.transport.version}</version>
-                <type>zip</type>
-            </dependency>
-
             <!--Metrics-->
             <dependency>
                 <groupId>org.wso2.carbon.metrics</groupId>
@@ -428,10 +403,6 @@
         <javax.ws.rs.version.range>[2.0.0, 3.0.0)</javax.ws.rs.version.range>
         <javax.websocket.version>1.1</javax.websocket.version>
         <javax.websocket.version.range>[1.1.0, 2.0.0)</javax.websocket.version.range>
-
-        <!--Transport-->
-        <carbon.messaging.version>3.0.0</carbon.messaging.version>
-        <carbon.transport.version>5.0.0-m1</carbon.transport.version>
 
         <!--Metrics-->
         <carbon.metrics.version>2.3.0</carbon.metrics.version>


### PR DESCRIPTION
## Purpose
Bumps, 
- Carbon UI Server version to 0.17.0
- Analytics Common version to v6.0.36
- Analytics version to v2.0.197

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
