### PR TITLE
Fix issue in dashboard settings/create pages

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardCreatePage.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardCreatePage.jsx
@@ -267,7 +267,7 @@ export default class DashboardCreatePage extends Component {
                             label={<FormattedMessage id="cancel.button" defaultMessage="Cancel" />}
                             style={{'margin':'30px 10px'}}
                             backgroundColor="rgb(13, 31, 39)"
-                            containerElement={<Link to={window.contextPath} />}
+                            containerElement={<Link to={`${window.contextPath}/`} />}
                         />
                     </FormPanel>
                     <Snackbar

--- a/components/dashboards-web-component/src/designer/DashboardSettings.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardSettings.jsx
@@ -236,7 +236,7 @@ export default class DashboardSettings extends Component {
                             label={<FormattedMessage id="cancel.button" defaultMessage="Cancel"/>}
                             style={{'margin': '30px 10px'}}
                             backgroundColor="rgb(13, 31, 39)"
-                            containerElement={<Link to={window.contextPath}/>}
+                            containerElement={<Link to={`${window.contextPath}/`}/>}
                         />
 
                     </FormPanel>


### PR DESCRIPTION
## Purpose
When user visits dashboard settings or create pages, click cancel and try again to visit those pages, empty page will be shown and the `/portal/` context is getting missed from the URL.

Resolves https://github.com/wso2/carbon-dashboards/issues/747

## Approach
This issue happens because the user is redirected to `/portal` instead of `/portal/` URL. This PR fixes that issue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes