### PR TITLE
Bumping react-vizgrammar version in Sales Dashboard Sample Gadgets

### DIFF
--- a/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
+++ b/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
@@ -63,15 +63,7 @@ export default class UniversalWidget extends ExtendedWidget {
 
     renderWidget() {
         return (
-            <div style={{ height:this.props.glContainer.height, width:this.props.glContainer.width }}>
-                <VizG
-                    config={this.state.config}
-                    metadata={this.state.metadata}
-                    data={this.state.data}
-                    height={this.props.glContainer.height}
-                    width={this.props.glContainer.height}
-                />
-            </div>
+            <VizG config={this.state.config} metadata={this.state.metadata} data={this.state.data} />
         );
     }
 

--- a/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
+++ b/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
@@ -73,7 +73,7 @@ export default class UniversalWidget extends ExtendedWidget {
 
     getHTTPClient() {
         let httpClient = Axios.create({
-            baseURL: window.location.origin+''+window.contextPath,
+            baseURL: window.location.origin+window.contextPath,
             timeout: 2000,
             headers: {"Authorization": "Bearer " + AuthManager.getUser().token},
         });

--- a/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
+++ b/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
@@ -39,7 +39,7 @@ export default class UniversalWidget extends ExtendedWidget {
     componentDidMount() {
         this.handleWidgetData = this.handleWidgetData.bind(this);
         this.getHTTPClient()
-            .get(`portal/apis/widgets/${this.props.widgetID}`)
+            .get(`apis/widgets/${this.props.widgetID}`)
             .then((message) => {
                 let providerConfiguration = message.data.configs.providerConfig;
                 super.getWidgetChannelManager().subscribeWidget(this.props.widgetID, this.handleWidgetData, providerConfiguration);
@@ -73,7 +73,7 @@ export default class UniversalWidget extends ExtendedWidget {
 
     getHTTPClient() {
         let httpClient = Axios.create({
-            baseURL: window.location.origin,
+            baseURL: window.location.origin+''+window.contextPath,
             timeout: 2000,
             headers: {"Authorization": "Bearer " + AuthManager.getUser().token},
         });

--- a/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
+++ b/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
@@ -63,7 +63,15 @@ export default class UniversalWidget extends ExtendedWidget {
 
     renderWidget() {
         return (
-            <VizG config={this.state.config} metadata={this.state.metadata} data={this.state.data}/>
+            <div style={{ height:this.props.glContainer.height, width:this.props.glContainer.width }}>
+                <VizG
+                    config={this.state.config}
+                    metadata={this.state.metadata}
+                    data={this.state.data}
+                    height={this.props.glContainer.height}
+                    width={this.props.glContainer.height}
+                />
+            </div>
         );
     }
 
@@ -73,7 +81,7 @@ export default class UniversalWidget extends ExtendedWidget {
 
     getHTTPClient() {
         let httpClient = Axios.create({
-            baseURL: window.location.origin+window.contextPath,
+            baseURL: window.location.origin + window.contextPath,
             timeout: 2000,
             headers: {"Authorization": "Bearer " + AuthManager.getUser().token},
         });

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
@@ -11,9 +11,8 @@
         "react": "^16.1.1",
         "react-dom": "^16.1.1",
         "react-simple-maps": "^0.9.0",
-        "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
@@ -12,7 +12,7 @@
         "react-dom": "^16.1.1",
         "react-simple-maps": "^0.9.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
@@ -11,8 +11,9 @@
         "react": "^16.1.1",
         "react-dom": "^16.1.1",
         "react-simple-maps": "^0.9.0",
+        "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.3",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
@@ -11,9 +11,8 @@
         "react": "^16.1.1",
         "react-dom": "^16.1.1",
         "react-simple-maps": "^0.9.0",
-        "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
@@ -12,7 +12,7 @@
         "react-dom": "^16.1.1",
         "react-simple-maps": "^0.9.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
@@ -11,8 +11,9 @@
         "react": "^16.1.1",
         "react-dom": "^16.1.1",
         "react-simple-maps": "^0.9.0",
+        "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.3",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "0.6.3",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.3",
+        "react-vizgrammar": "^0.6.7",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"


### PR DESCRIPTION
## Purpose
Bumping react-vizgrammar version in Sales Dashboard Sample Gadgets

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 1.8.0_144, Node.JS v8.5.0, NPM v5.3.0