### PR TITLE
Fix blank error message in login page

### DIFF
--- a/components/dashboards-web-component/src/auth/Login.jsx
+++ b/components/dashboards-web-component/src/auth/Login.jsx
@@ -141,7 +141,6 @@ export default class Login extends Component {
                             onChange={(e) => {
                                 this.setState({
                                     username: e.target.value,
-                                    error: false,
                                 });
                             }}
                         />
@@ -154,7 +153,6 @@ export default class Login extends Component {
                             onChange={(e) => {
                                 this.setState({
                                     password: e.target.value,
-                                    error: false,
                                 });
                             }}
                         />
@@ -184,6 +182,7 @@ export default class Login extends Component {
                         autoHideDuration="4000"
                         contentStyle={styles.messageBox}
                         bodyStyle={styles.errorMessage}
+                        onRequestClose={() => this.setState({error: '', showError: false})}
                     />
                 </div>
             </MuiThemeProvider>


### PR DESCRIPTION
## Purpose
This PR fixes the issue which shown blank error messages after failed login attempt in dashboard login page.

Resolves https://github.com/wso2/carbon-dashboards/issues/758
## Approach
As a fix this changeset clears the React.js state which is used to show the error message after error message closes. This fixes the issue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes