### PR TITLE
Hide universal widget from widget list

### DIFF
--- a/components/dashboards-web-component/src/designer/components/WidgetsList.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetsList.jsx
@@ -164,8 +164,14 @@ export default class WidgetsList extends React.Component {
                 <Divider/>
                 {
                     this.state.widgets.map(widget => {
-                        return <WidgetListThumbnail widgetID={widget.id} isDisplayed={this.isDisplayed(widget.name)}
-                                                    data={this.state.widgetList} widgetName={widget.name}/>;
+                        if (widget.id !== 'UniversalWidget') {
+                            return <WidgetListThumbnail
+                                widgetID={widget.id}
+                                isDisplayed={this.isDisplayed(widget.name)}
+                                data={this.state.widgetList}
+                                widgetName={widget.name}
+                            />;
+                        }
                     })
                 }
                 <Divider/>


### PR DESCRIPTION
## Purpose
This PR hides the UniversalWidget from the widget list in dashboard designer.

Resolves https://github.com/wso2/carbon-dashboards/issues/743

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes