### PR TITLE
Adding unsubscribe widget on preview close

### DIFF
--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
@@ -466,7 +466,9 @@ class GadgetsGenerationWizard extends Component {
                         onRequestClose={() => this.setState({ previewGadget: false })}
                         repositionOnUpdate
                     >
-                        <ChartPreviewer config={this.state.previewConfiguration} />
+                        <ChartPreviewer
+                            config={this.state.previewConfiguration}
+                        />
                     </Dialog>
                     <FormPanel
                         title={<FormattedMessage id="create.widget" defaultMessage="Create Widget" />}

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPreview/PreviewerWidget.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPreview/PreviewerWidget.jsx
@@ -34,6 +34,11 @@ export default class PreviewerWidget extends React.Component {
         this.channelManager.subscribeWidget(config.id, this._handleDataReceived, config.configs.providerConfig);
     }
 
+    componentWillUnmount() {
+        let { config } = this.props;
+        this.channelManager.unsubscribeWidget(config.id);
+    }
+
     _handleDataReceived(data) {
         this.setState({
             metadata: data.metadata,

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPreview/PreviewerWidget.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPreview/PreviewerWidget.jsx
@@ -35,8 +35,7 @@ export default class PreviewerWidget extends React.Component {
     }
 
     componentWillUnmount() {
-        let { config } = this.props;
-        this.channelManager.unsubscribeWidget(config.id);
+        this.channelManager.unsubscribeWidget(this.props.config.id);
     }
 
     _handleDataReceived(data) {


### PR DESCRIPTION
## Purpose
> Adding un-subscription to the channel manager when preview dialog is closed

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes