### PR TITLE
Update react-vizgrammer version to 0.6.9

### DIFF
--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.8",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"


### PR DESCRIPTION
## Purpose
This PR updates `react-vizgrammer` version to `0.6.9`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes