### PR TITLE
Removed renderWidget method from the UniversalWidget

### DIFF
--- a/samples/widgets/UniversalWidget/package.json
+++ b/samples/widgets/UniversalWidget/package.json
@@ -7,7 +7,7 @@
         "axios": "^0.17.1",
         "react": "^16.2.0",
         "react-dom": "^16.2.0",
-        "react-vizgrammar": "^0.6.7",
+        "react-vizgrammar": "^0.6.9",
         "rimraf": "^2.6.2"
     },
     "scripts": {

--- a/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
+++ b/samples/widgets/UniversalWidget/src/UniversalWidget.jsx
@@ -61,7 +61,7 @@ export default class UniversalWidget extends ExtendedWidget {
         })
     }
 
-    renderWidget() {
+    render() {
         return (
             <div style={{width: this.props.glContainer.width, height: this.props.glContainer.height }}>
                 <VizG
@@ -72,7 +72,7 @@ export default class UniversalWidget extends ExtendedWidget {
                     width={this.props.glContainer.width}
                 />
             </div>
-        );
+        )
     }
 
     handleResize() {


### PR DESCRIPTION
## Purpose
Removed renderWidget method from the UniversalWidget to fix the styling issues associated with the UniversalWidget

## Test environment
Node.JS v8.5.0, NPM v5.3.0