### PR TITLE
Removed renderWidget function from the sample widgets

### DIFF
--- a/samples/widgets/Subscriber/src/Subscriber.jsx
+++ b/samples/widgets/Subscriber/src/Subscriber.jsx
@@ -60,7 +60,7 @@ class Subscriber extends Widget {
         this.set = [];
     }
 
-    renderWidget() {
+    render() {
         return (
             <MuiThemeProvider
                 muiTheme={getMuiTheme(darkBaseTheme)}

--- a/samples/widgets/UserInfo/src/UserInfo.jsx
+++ b/samples/widgets/UserInfo/src/UserInfo.jsx
@@ -31,10 +31,8 @@ class UserInfo extends Widget {
         super(props);
     }
 
-    /**
-     * Implements the renderWidget function.
-     */
-    renderWidget () {
+
+    render() {
         let styles = {
             container: {
                 fontFamily: 'Roboto, sans-serif',

--- a/samples/widgets/WidgetState/src/WidgetState.jsx
+++ b/samples/widgets/WidgetState/src/WidgetState.jsx
@@ -39,7 +39,7 @@ class WidgetState extends Widget {
     /**
      * Implements the renderWidget function.
      */
-    renderWidget () {
+    render() {
         let styles = {
             container: {
                 font: '12px Roboto, sans-serif',

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/src/CustomersPerYear.jsx
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/src/CustomersPerYear.jsx
@@ -139,7 +139,6 @@ class CustomersPerYear extends Widget {
                     width={this.props.glContainer.width}
                 />
             </div>
-
         );
     }
 }

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/src/RevenueByCountry.jsx
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/src/RevenueByCountry.jsx
@@ -94,7 +94,7 @@ class RevenueByCountry extends Widget {
         this.setState({width: this.props.glContainer.width, height: this.props.glContainer.height});
     }
 
-    renderWidget() {
+    render() {
         return (
             <div className="sample-dashboard-content" style={{height: this.props.glContainer.height}}>
                 <div className="sample-dashboard-content-rev-text" style={{height: '100%', color: '#5d6e77'}}  >


### PR DESCRIPTION
## Purpose
removing the renderWidget function from the sample widgets to remove it from the base-widget

## Test environment
Node.JS v8.5.0, NPM v5.3.0