### PR TITLE
Removing renderWidget function from the render function of the base widget

### DIFF
--- a/base-widget/src/Widget.jsx
+++ b/base-widget/src/Widget.jsx
@@ -168,17 +168,4 @@ export default class Widget extends Component {
             username: (user && user.username) ? user.username : null,
         };
     }
-
-    /**
-     * Render widget.
-     * 
-     * @return {string} HTML content
-     */
-    render() {
-        return (
-            <div style={{ padding: '30px 15px 15px 15px' }}>
-                {this.renderWidget()}
-            </div>
-        );
-    }
 }


### PR DESCRIPTION
## Purpose
Removed renderWidget function call from the base widget as it is no longer required.

## Test environment
Node.JS v8.5.0, NPM v5.3.0