### PR TITLE
Adding 'append' configuration for some chart types

### DIFF
--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPropertyGenerators/main/LineAreaBarChart.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPropertyGenerators/main/LineAreaBarChart.jsx
@@ -229,6 +229,16 @@ class LineAreaBar extends Component {
                     <CardMedia
                         expandable
                     >
+                        <br />
+                        <br />
+                        <SwitchProperty
+                            id="append"
+                            value={this.state.configuration.append}
+                            fieldName="Append new data to the chart"
+                            onChange={(id, value) => this.handleMainChartPropertyChange(id, value)}
+                        />
+                        <br />
+                        <br />
                         <TextProperty
                             id="xAxisLabel"
                             value={this.state.configuration.xAxisLabel}

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPropertyGenerators/main/PieChart.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPropertyGenerators/main/PieChart.jsx
@@ -180,6 +180,16 @@ class Pie extends Component {
                     <CardMedia
                         expandable
                     >
+                        <br />
+                        <br />
+                        <SwitchProperty
+                            id="append"
+                            value={this.state.configuration.append}
+                            fieldName="Append new data to the chart"
+                            onChange={(id, value) => this.handleChartPropertyChange(id, value)}
+                        />
+                        <br />
+                        <br />
                         <SelectProperty
                             id="legendOrientation"
                             value={this.state.configuration.legendOrientation}

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPropertyGenerators/main/ScatterChart.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPropertyGenerators/main/ScatterChart.jsx
@@ -202,6 +202,16 @@ class Scatter extends Component {
                     <CardMedia
                         expandable
                     >
+                        <br />
+                        <br />
+                        <SwitchProperty
+                            id="append"
+                            value={this.state.configuration.append}
+                            fieldName="Append new data to the chart"
+                            onChange={(id, value) => this.handleMainChartPropertyChange(id, value)}
+                        />
+                        <br />
+                        <br />
                         <TextProperty
                             id="xAxisLabel"
                             value={this.state.configuration.xAxisLabel}

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/utils/Configurations.js
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/utils/Configurations.js
@@ -68,6 +68,7 @@ const Configurations = {
             disableHorizontalGrid: false,
             timeFormat: '',
             legendOrientation: '',
+            append: true,
         },
         scatterChart: {
             type: 'scatter',
@@ -99,6 +100,7 @@ const Configurations = {
             legendOrientation: '',
             xAxisTickCount: '',
             yAxisTickCount: '',
+            append: true,
         },
         pieChart: {
             charts: [
@@ -116,6 +118,7 @@ const Configurations = {
                 legendTextColor: '',
             },
             legendOrientation: '',
+            append: true,
         },
         numberChart: {
             x: '',

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/utils/UtilFunctions.js
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/utils/UtilFunctions.js
@@ -187,6 +187,9 @@ class UtilFunctions {
         if (configuration.legendOrientation === '') {
             delete configuration.legendOrientation;
         }
+        if (configuration.append) {
+            delete configuration.append;
+        }
         return configuration;
     }
 
@@ -275,6 +278,9 @@ class UtilFunctions {
         if (configuration.yAxisTickCount === '') {
             delete configuration.yAxisTickCount;
         }
+        if (configuration.append) {
+            delete configuration.append;
+        }
         return configuration;
     }
 
@@ -344,6 +350,9 @@ class UtilFunctions {
             default :
                 configuration.charts[0].mode = Types.chart.pie;
                 break;
+        }
+        if (configuration.append) {
+            delete configuration.append;
         }
         delete configuration.chartType;
         return configuration;


### PR DESCRIPTION
## Purpose
> Adding `append` boolean option for some charts.

## Goals
> Allowing the user to optionally select appending data from streaming providers

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes