### PR TITLE
Reduce the token refreshing timeout to 60s.

### DIFF
--- a/components/dashboards-web-component/src/auth/SecuredRouter.jsx
+++ b/components/dashboards-web-component/src/auth/SecuredRouter.jsx
@@ -55,7 +55,7 @@ export default class SecuredRouter extends Component {
                     AuthManager.authenticateWithRefreshToken();
                 }
             }
-        }, 600000);
+        }, 60000);
     }
     /**
      * Render routing.


### PR DESCRIPTION
## Purpose
This PR reduces the interval which is used to check and refresh access tokens to 60 secs (which is less than timeout skew). 

If the checking interval is greater than the timeout skew, there can be situations which the logic misses possible token expiry.