### PR TITLE
Made widgets panel visible by default in designer

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardDesigner.jsx
@@ -103,9 +103,9 @@ export default class DashboardDesigner extends Component {
         this.state = {
             dashboardId: this.props.match.params.dashboardId,
             dashboard: undefined,
-            leftSidebarOpen: false,
-            leftSidebarPanel: sidebarPanels.PAGES,
-            designerClass: 'designer-container-expanded',
+            leftSidebarOpen: true,
+            leftSidebarPanel: sidebarPanels.WIDGETS,
+            designerClass: 'designer-container-collapsed',
             redirect: false,
             redirectUrl: '',
             widgetConfigPanelOpen: false,


### PR DESCRIPTION
## Purpose
By default, the widgets panel in dashboard designer is collapsed. This PR fixes that issue and makes the widgets panel open by default when the user visits the designer. This will provide a clue about the next operation user has to do with the designer, i.e. dragging and dropping a widget.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes