### PR TITLE
Refactoring dashboard creator role configuration

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/roles/provider/Roles.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/roles/provider/Roles.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.dashboards.core.bean.roles.provider;
 
-import org.wso2.carbon.analytics.permissions.bean.Role;
 import org.wso2.carbon.config.annotation.Element;
 
 import java.util.Collections;
@@ -30,10 +29,10 @@ import java.util.List;
 public class Roles {
 
     @Element(description = "list of dashboard creator roles")
-    private List<Role> creator = Collections.emptyList();
+    private List<String> creators = Collections.emptyList();
 
-    public List<Role> getCreator() {
-        return creator;
+    public List<String> getCreators() {
+        return creators;
     }
 
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -349,7 +349,8 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
     private boolean checkPermissions(String user, String dashboardUrl, String originComponent) {
         switch (originComponent) {
             case "designer":
-                return hasPermission(user, dashboardUrl, PERMISSION_SUFFIX_EDITOR);
+                return hasPermission(user, dashboardUrl, PERMISSION_SUFFIX_EDITOR) ||
+                        hasPermission(user, dashboardUrl, PERMISSION_SUFFIX_OWNER);
             case "settings":
                 return hasPermission(user, dashboardUrl, PERMISSION_SUFFIX_OWNER);
             default:

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/roles/provider/RolesProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/roles/provider/RolesProvider.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.dashboards.core.internal.roles.provider;
 
-import org.wso2.carbon.analytics.permissions.bean.Role;
 import org.wso2.carbon.dashboards.core.bean.DashboardConfigurations;
 
 import java.util.ArrayList;
@@ -30,25 +29,23 @@ import java.util.List;
 public class RolesProvider {
 
     private static final String ROLE_ID = "admin";
-    private static final String ROLE_NAME = "admin";
 
-    private List<Role> creatorRoles = new ArrayList<Role>();
+    private List<String> creatorRoleIds = new ArrayList<>();
 
     public RolesProvider(DashboardConfigurations dashboardConfigurations) {
-        creatorRoles.add(new Role(ROLE_ID, ROLE_NAME));
+        creatorRoleIds.add(ROLE_ID);
         if (dashboardConfigurations.getRoles() != null) {
             readConfigs(dashboardConfigurations);
         }
     }
 
     private void readConfigs(DashboardConfigurations dashboardConfigurations) {
-        if (!dashboardConfigurations.getRoles().getCreator().isEmpty()) {
-            creatorRoles = new ArrayList<>();
-            creatorRoles = dashboardConfigurations.getRoles().getCreator();
+        if (!dashboardConfigurations.getRoles().getCreators().isEmpty()) {
+            creatorRoleIds = dashboardConfigurations.getRoles().getCreators();
         }
     }
 
-    public List<Role> getCreatorRoles() {
-        return creatorRoles;
+    public List<String> getCreatorRoleIds() {
+        return creatorRoleIds;
     }
 }


### PR DESCRIPTION
## Purpose
This PR refactors the dashboard creator role configuration in `deployment.yaml`. Earlier the dashboard creator configuration has been depicted as follows in the `deployment.yaml`.

```yaml
wso2.dashboard:
  roles:
    creators:
      -
        id: 1
        name: role_1
      -
        id: 2
        name: role_2
```

Since the role details are already there in the same configuration file, with this change only providing the role IDs will be sufficient. New `deployment.yaml` configuration looks as follows.

```yaml
wso2.dashboard:
  roles:
    creators: [1, 2]
```

In addition to that this PR fixes an issue in dashboard permissions, i.e. when a particular role has `owner` permission it does not allow to design the dashboard. Instead `owner` permission should have total access to that dashboard.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes