### PR TITLE
Bump msf4j, carbon analytics, carbon analytics-common versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,8 +410,8 @@
         <carbon.datasources.version>1.1.2</carbon.datasources.version>
 
         <!--Analytics-->
-        <carbon.analytics.version>2.0.210</carbon.analytics.version>
-        <carbon.analytics.version.range>[2.0.210, 3.0.0)</carbon.analytics.version.range>
+        <carbon.analytics.version>2.0.246</carbon.analytics.version>
+        <carbon.analytics.version.range>[2.0.246, 3.0.0)</carbon.analytics.version.range>
         <!--Analytics common-->
         <carbon.analytics-common.version>6.0.42</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.42, 7.0.0)</carbon.analytics-common.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -413,8 +413,8 @@
         <carbon.analytics.version>2.0.246</carbon.analytics.version>
         <carbon.analytics.version.range>[2.0.246, 3.0.0)</carbon.analytics.version.range>
         <!--Analytics common-->
-        <carbon.analytics-common.version>6.0.42</carbon.analytics-common.version>
-        <carbon.analytics-common.version.range>[6.0.42, 7.0.0)</carbon.analytics-common.version.range>
+        <carbon.analytics-common.version>6.0.51</carbon.analytics-common.version>
+        <carbon.analytics-common.version.range>[6.0.51, 7.0.0)</carbon.analytics-common.version.range>
 
         <!--OSGi-->
         <org.osgi.api.version>6.0.0</org.osgi.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         <carbon.uiserver.version.range>[0.19.2, 1.0.0]</carbon.uiserver.version.range>
 
         <!--MSF4J-->
-        <msf4j-core.version>2.5.0</msf4j-core.version>
+        <msf4j-core.version>2.5.2</msf4j-core.version>
         <msf4j-core.version.range>[2.5.0, 3.0.0)</msf4j-core.version.range>
         <javax.ws.rs.version>2.0</javax.ws.rs.version>
         <javax.ws.rs.version.range>[2.0.0, 3.0.0)</javax.ws.rs.version.range>


### PR DESCRIPTION
## Purpose
- Bumps msf4j version to v2.5.2
- Bumps carbon analytics version to v2.0.246
- Bumps carbon analytics-common version to v6.0.51

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
