### PR TITLE
Fix theme issue in light theme

### DIFF
--- a/components/dashboards-web-component/public/css/dashboard.css
+++ b/components/dashboards-web-component/public/css/dashboard.css
@@ -119,6 +119,14 @@ a {
     margin-bottom: 10px;
 }
 
+.content-box {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+}
+
 .content-drawer-closed {
     padding-left: 0;
 }

--- a/components/dashboards-web-component/src/viewer/DashboardView.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardView.jsx
@@ -90,6 +90,7 @@ class DashboardView extends React.Component {
             dashboardContent: [],
             open: true,
             contentClass: "content-drawer-opened",
+            isDark: false,
             muiTheme: darkMuiTheme,
             requestHideLoading: false,
             invalidURL: false,
@@ -142,10 +143,11 @@ class DashboardView extends React.Component {
         }
     }
 
-    handleTheme(isDarkTheme) {
-        isDarkTheme ? document.body.className = 'viewer-dark' : document.body.className = 'viewer-light';
-        let muiTheme = isDarkTheme ? getMuiTheme(darkMuiTheme) : getMuiTheme(lightMuiTheme);
-        this.setState({ muiTheme: muiTheme });
+    handleTheme(isDark) {
+        this.setState({
+            muiTheme: isDark ? getMuiTheme(darkMuiTheme) : getMuiTheme(lightMuiTheme),
+            isDark,
+        });
     }
 
     /**
@@ -192,6 +194,8 @@ class DashboardView extends React.Component {
             this.state.requestHideLoading = false;
         }
 
+        const themeClass = this.state.isDark ? 'viewer-dark' : 'viewer-light';
+
         return (
             <MuiThemeProvider muiTheme={this.state.muiTheme}>
                 {
@@ -206,7 +210,7 @@ class DashboardView extends React.Component {
                                                       match={this.props.match}
                                                       handleThemeSwitch={this.handleTheme}/>
                             </Drawer>
-                            <div className={this.state.contentClass}>
+                            <div className={`content-box ${this.state.contentClass} ${themeClass}`}>
                                 <AppBar
                                     title=""
                                     iconClassNameRight="muidocs-icon-navigation-expand-more"


### PR DESCRIPTION
## Purpose
In the dashboard viewer, once the light theme is selected and navigated back to the dashboard listing or login pages color conflicts happen. This PR fixes that issue.

Resolves https://github.com/wso2/carbon-dashboards/issues/834

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes