### PR TITLE
Fix blank menu items in dashboard view page menu

### DIFF
--- a/components/dashboards-web-component/src/viewer/DashboardView.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardView.jsx
@@ -28,7 +28,7 @@ import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
 import DashboardRenderingComponent from '../utils/DashboardRenderingComponent';
-import PagesNavigationPanel from '../designer/components/PagesNavigationPanel';
+import Sidebar from './components/Sidebar';
 import DashboardAPI from '../utils/apis/DashboardAPI';
 import DashboardUtils from '../utils/DashboardUtils';
 import AuthManager from '../auth/utils/AuthManager';
@@ -128,10 +128,13 @@ class DashboardView extends React.Component {
     }
 
     setDashboardProperties(response) {
+        const dashboard = response.data;
+        dashboard.pages = JSON.parse(dashboard.pages);
         this.setState({
-            dashboardName: response.data.name,
-            dashboardContent: (JSON.parse(response.data.pages)),
-            landingPage: response.data.landingPage
+            dashboard,
+            dashboardName: dashboard.name,
+            dashboardContent: dashboard.pages,
+            landingPage: dashboard.landingPage,
         });
     }
 
@@ -195,6 +198,11 @@ class DashboardView extends React.Component {
         }
 
         const themeClass = this.state.isDark ? 'viewer-dark' : 'viewer-light';
+        const dashboard = this.state.dashboard || {
+            name: '',
+            pages: [],
+            landingPage: '',
+        };
 
         return (
             <MuiThemeProvider muiTheme={this.state.muiTheme}>
@@ -203,12 +211,15 @@ class DashboardView extends React.Component {
                         <Error404 />:
                         <div>
                             <Drawer open={this.state.open} className="viewer-drawer">
-                                <PagesNavigationPanel dashboardId={this.props.match.params.id}
-                                                      dashboardContent={this.state.dashboardContent}
-                                                      dashboardName={this.state.dashboardName}
-                                                      toggled={this.state.toggled}
-                                                      match={this.props.match}
-                                                      handleThemeSwitch={this.handleTheme}/>
+                                <Sidebar
+                                    dashboard={dashboard}
+                                    dashboardId={this.props.match.params.id}
+                                    dashboardContent={this.state.dashboardContent}
+                                    dashboardName={this.state.dashboardName}
+                                    toggled={this.state.toggled}
+                                    match={this.props.match}
+                                    handleThemeSwitch={this.handleTheme}
+                                />
                             </Drawer>
                             <div className={`content-box ${this.state.contentClass} ${themeClass}`}>
                                 <AppBar

--- a/components/dashboards-web-component/src/viewer/components/PageMenu.jsx
+++ b/components/dashboards-web-component/src/viewer/components/PageMenu.jsx
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import { List, ListItem } from 'material-ui/List';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+
+/**
+ * Generates page menu in viewer.
+ */
+class PageMenu extends Component {
+    /**
+     * Generate pages menu.
+     *
+     * @param {{}} page Page object
+     * @param {string} parentUrl URL of the parent page
+     * @returns {XML} HTML content
+     */
+    generateMenu(page, parentUrl) {
+        // Generate the URL of the current page.
+        const url = parentUrl ? parentUrl + '/' + page.id : page.id;
+
+        // Generate sub-pages.
+        let subpages = [];
+        if (page.pages) {
+            subpages = page.pages.map((subpage) => {
+                return this.generateMenu(subpage, url);
+            });
+        }
+
+        // Build and return the page structure.
+        return (
+            <ListItem
+                initiallyOpen
+                primaryText={page.name}
+                nestedItems={subpages}
+                onClick={() => {
+                    this.props.history.push(`${window.contextPath}/dashboards/${this.props.dashboard.url}/${url}`);
+                }}
+            />
+        );
+    }
+
+    /**
+     * Renders menu.
+     *
+     * @returns {XML} HTML content
+     */
+    render() {
+        return (
+            <div>
+                {
+                    this.props.dashboard.pages.map((page) => {
+                        return (
+                            <List>
+                                {this.generateMenu(page)}
+                            </List>
+                        );
+                    })
+                }
+            </div>
+        );
+    }
+}
+
+PageMenu.propTypes = {
+    dashboard: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        pages: PropTypes.array,
+    }).isRequired,
+};
+
+export default withRouter(PageMenu);

--- a/components/dashboards-web-component/src/viewer/components/Sidebar.jsx
+++ b/components/dashboards-web-component/src/viewer/components/Sidebar.jsx
@@ -19,48 +19,16 @@
 
 import React from 'react';
 import Toggle from 'material-ui/Toggle';
-import Paper from 'material-ui/Paper';
-import Menu from 'material-ui/Menu';
-import MenuItem from 'material-ui/MenuItem';
-import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
-import {Link} from 'react-router-dom';
+import PageMenu from './PageMenu';
 
 import {FormattedMessage} from 'react-intl';
 
-class PagesNavigationPanel extends React.Component {
+export default class Sidebar extends React.Component {
     constructor(props) {
         super(props);
         this.loadTheme = this.loadTheme.bind(this);
-        this.generateDashboardPagesMenu = this.generateDashboardPagesMenu.bind(this);
         this.isThemeSwitchToggled = this.isThemeSwitchToggled.bind(this);
         this.setThemeSwitchToggled = this.setThemeSwitchToggled.bind(this);
-    }
-
-    generateDashboardPagesMenu(page, parentPageId) {
-        if (!page.pages) {
-            return (
-                <Link
-                    to={`${this.props.match.params[0]}/dashboards/${this.props.match.params.id}/` + (parentPageId ? parentPageId + "/" + page.id : page.id)}
-                    replace={true}>
-                    <MenuItem className="pages-menu-item" primaryText={page.name}/>
-                </Link>
-            );
-        } else {
-            parentPageId = parentPageId ? parentPageId + "/" + page.id : page.id;
-            return (
-                <section>
-                    <Link to={`${this.props.match.params[0]}/dashboards/${this.props.match.params.id}/` + parentPageId}
-                          replace={true}>
-                        <MenuItem className="pages-menu-item" primaryText={page.name}/>
-                    </Link>
-                    <MenuItem primaryText="">
-                        {page.pages.map(page => {
-                            return this.generateDashboardPagesMenu(page, parentPageId)
-                        })}
-                    </MenuItem>
-                </section>
-            );
-        }
     }
 
     componentWillMount() {
@@ -68,18 +36,6 @@ class PagesNavigationPanel extends React.Component {
     }
 
     render() {
-        if (this.props.dashboardContent) {
-            this.props.pagesList = this.props.dashboardContent.map(page => {
-                return (
-                    <Paper className="pages-menu" style={{"backgroundColor":"transparent"}}>
-                        <Menu className="pages-menu">
-                            {this.generateDashboardPagesMenu(page)}
-                        </Menu>
-                    </Paper>
-                );
-            });
-        }
-
         return (
             <div>
                 <div className="dashboard-view-product-logo">
@@ -88,9 +44,7 @@ class PagesNavigationPanel extends React.Component {
                 <div className="dashboard-view-product-name">
                     {this.props.dashboardName}
                 </div>
-                <div>
-                    {this.props.pagesList}
-                </div>
+                <PageMenu dashboard={this.props.dashboard} />
                 <div className="dark-light-theme-switch-div">
                     <FormattedMessage id="light" defaultMessage="Light"/>
                     <Toggle
@@ -138,5 +92,3 @@ class PagesNavigationPanel extends React.Component {
         head.appendChild(link);
     }
 }
-
-export default PagesNavigationPanel;


### PR DESCRIPTION
## Purpose
In dashboard viewer, page menu renders two entries for a single page (one of them is blank). This PR fixes that issue.

Resolves https://github.com/wso2/carbon-dashboards/issues/833

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes