### PR TITLE
Fix widget configuration panel overlap issue in designer

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardDesigner.css
+++ b/components/dashboards-web-component/src/designer/DashboardDesigner.css
@@ -50,7 +50,7 @@
 }
 
 .dashboard-designer-expanded-all {
-    width: 68%;
+    width: calc(100% - 600px);
     padding: 8px 10px 0 325px;
     color: white;
     height: 89vh;
@@ -58,7 +58,7 @@
 }
 
 .dashboard-designer-container-collapsed-left {
-    width: 82%;
+    width: calc(100% - 330px);
     padding: 8px 10px 0 65px;
     color: white;
     height: 89vh;
@@ -82,7 +82,6 @@
 .widget-configuration-panel {
     padding-top: 125px;
     padding-left: 10px;
-    z-index: 0 !important;
 }
 
 .widget-configuration-panel-header {

--- a/components/dashboards-web-component/src/designer/components/WidgetsList.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetsList.jsx
@@ -78,6 +78,9 @@ export default class WidgetsList extends React.Component {
 
     setWidgets(response) {
         widgets = response.data;
+        widgets.sort(function (a, b) {
+            return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
+        });
         this.setState({
             widgets: widgets,
             filteredWidgetSet: new Set(widgets.map((widget) => {


### PR DESCRIPTION
## Purpose
> This will provide fixes for following issues,
#746 
#772 
#773 

## Goals
Provide more smooth user experience for the dashboard designers.

## Approach
This PR will introduce a calc method and calculate the designer view and widget configuration panel width according to window width. So it will not overlap different screen resolutions.

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
Node - v8.8.1-linux-x64

Resolves #746 
Resolves #772 
Resolves #773 
 
  