### PR TITLE
Introducing field types for rendering data provider config fields

### DIFF
--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/wso2/carbon-dashboards#readme",
   "dependencies": {
     "axios": "^0.16.2",
+    "brace": "^0.11.0",
     "css-loader": "^0.28.4",
     "golden-layout": "^1.5.9",
     "html-loader": "^0.5.0",
@@ -28,6 +29,7 @@
     "prop-types": "^15.6.0",
     "qs": "^6.5.1",
     "react": "^16.1.1",
+    "react-ace": "^5.9.0",
     "react-color": "^2.13.8",
     "react-dom": "^16.1.1",
     "react-intl": "^2.4.0",

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -54,7 +54,7 @@ const styles = {
     successMessage: { backgroundColor: '#4CAF50', color: 'white' },
     completedStepperText: {color: 'white'},
     activeStepperText: { color: '#0097A7' },
-    inactiveStepperText: { color: '#9E9E9E' },
+    inactiveStepperText: { color: '#FFFFFF', opacity: 0.3 },
 };
 
 /**
@@ -73,6 +73,7 @@ class GadgetsGenerationWizard extends Component {
             providerType: '',
             providersList: [],
             providerConfiguration: {},
+            providerConfigRenderTypes: {},
             chartConfiguration: {},
             metadata: {
                 names: ['rpm', 'torque', 'horsepower', 'EngineType'],
@@ -101,7 +102,7 @@ class GadgetsGenerationWizard extends Component {
     }
 
     componentDidMount() {
-        const api = new GadgetsGenerationAPI()
+        const api = new GadgetsGenerationAPI();
         api.getProvidersList().then((response) => {
             this.setState({
                 providersList: response.data,
@@ -131,12 +132,14 @@ class GadgetsGenerationWizard extends Component {
             if (providerType === 'RDBMSBatchDataProvider') {
                 this.setState({
                     providerType,
+                    providerConfigRenderTypes: UtilFunctions.getDefaultH2RenderTypes(),
                     providerConfiguration: UtilFunctions.getDefaultH2Config(),
                 });
             } else {
                 this.setState({
                     providerType,
-                    providerConfiguration: response.data,
+                    providerConfigRenderTypes: response.data[0],
+                    providerConfiguration: response.data[1],
                 });
             }
         }).catch(() => {
@@ -331,6 +334,7 @@ class GadgetsGenerationWizard extends Component {
                         providersList={this.state.providersList}
                         providerType={this.state.providerType}
                         configuration={this.state.providerConfiguration}
+                        configRenderTypes={this.state.providerConfigRenderTypes}
                         handleProviderTypeChange={this.handleProviderTypeChange}
                         handleProviderConfigPropertyChange={this.handleProviderConfigPropertyChange}
                     />

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/ProviderConfigurator.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/ProviderConfigurator.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/ProviderConfigurator.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/ProviderConfigurator.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -24,7 +24,11 @@ import MenuItem from 'material-ui/MenuItem';
 // App Components
 import TextProperty from './inputTypes/TextProperty';
 import SwitchProperty from './inputTypes/SwitchProperty';
+import CodeProperty from './inputTypes/CodeProperty';
+// Util Functions
 import UtilFunctions from '../utils/UtilFunctions';
+// App Constants
+import Types from '../utils/Types';
 
 /**
  * Displays data provider selection, and the properties related to the selected provider type
@@ -34,11 +38,15 @@ class ProviderConfigurator extends Component {
         super(props);
         this.state = {
             configuration: props.configuration,
+            configRenderTypes: props.configRenderTypes,
         };
     }
 
     componentWillReceiveProps(props) {
-        this.setState({configuration: props.configuration});
+        this.setState({
+            configuration: props.configuration,
+            configRenderTypes: props.configRenderTypes,
+        });
     }
 
     /**
@@ -53,31 +61,18 @@ class ProviderConfigurator extends Component {
         }
 
         return propertyKeys.map(key => (
-            this.renderAsInputField(key)
+            this.renderAsInputField(key, this.state.configRenderTypes[key])
         ));
     }
 
     /**
      * Returns input fields according to the value provided
      * @param value
+     * @param type
      */
-    renderAsInputField(value) {
-        switch (typeof (this.state.configuration[value])) {
-            case ('number'):
-                return (
-                    <div>
-                        <TextProperty
-                            id={value}
-                            value={this.props.configuration[value]}
-                            fieldName={UtilFunctions.toSentenceCase(value)}
-                            onChange={(id, value) => this.props.handleProviderConfigPropertyChange(id, value)}
-                            number
-                            fullWidth
-                        />
-                        <br />
-                    </div>
-                );
-            case ('boolean'):
+    renderAsInputField(value, type) {
+        switch (type) {
+            case (Types.inputFields.SWITCH):
                 return (
                     <div>
                         <br />
@@ -85,6 +80,20 @@ class ProviderConfigurator extends Component {
                             id={value}
                             value={this.props.configuration[value]}
                             fieldName={UtilFunctions.toSentenceCase(value)}
+                            onChange={(id, value) => this.props.handleProviderConfigPropertyChange(id, value)}
+                        />
+                        <br />
+                    </div>
+                );
+            case (Types.inputFields.SQL_CODE):
+            case (Types.inputFields.SIDDHI_CODE):
+                return (
+                    <div>
+                        <CodeProperty
+                            id={value}
+                            value={this.props.configuration[value]}
+                            fieldName={UtilFunctions.toSentenceCase(value)}
+                            mode={(type === Types.inputFields.SQL_CODE) ? 'sql' : 'text'}
                             onChange={(id, value) => this.props.handleProviderConfigPropertyChange(id, value)}
                         />
                         <br />
@@ -98,6 +107,8 @@ class ProviderConfigurator extends Component {
                             value={this.props.configuration[value]}
                             fieldName={UtilFunctions.toSentenceCase(value)}
                             onChange={(id, value) => this.props.handleProviderConfigPropertyChange(id, value)}
+                            number={type === Types.inputFields.NUMBER}
+                            multiLine={type === Types.inputFields.TEXT_AREA}
                             fullWidth
                         />
                         <br />

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/CodeProperty.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/CodeProperty.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/CodeProperty.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/CodeProperty.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/CodeProperty.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/CodeProperty.jsx
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+import React from 'react';
+// Ace Editor Components
+import AceEditor from 'react-ace';
+import 'brace/mode/sql';
+import 'brace/mode/text';
+import 'brace/theme/tomorrow_night_eighties';
+
+const styles = {
+    aceWrapper: {
+        position: 'relative',
+        float: 'left',
+        width: '50%'
+    },
+    aceEditor: {
+        theme: 'tomorrow_night_eighties',
+        fontSize: 18,
+    },
+
+};
+
+/**
+ * Represents a property that refers to given meta data from stream, for its value
+ */
+class CodeProperty extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            isFocused: false,
+        }
+    }
+
+    getLabelStyle() {
+        return {
+            fontSize: (12),
+            color: (this.state.isFocused ? '#0097A7' : '#FFFFFF'),
+            opacity: (this.state.isFocused ? 1 : 0.3),
+        };
+    }
+
+    render() {
+        return (
+            <div>
+                <br />
+                <div style={{ marginBottom: 10 }}>
+                    <a style={this.getLabelStyle()}>
+                        {(this.props.fieldName) ? (this.props.fieldName) : (null)}
+                    </a>
+                </div>
+                <AceEditor
+                    mode={this.props.mode}
+                    name={this.props.id}
+                    theme={styles.aceEditor.theme}
+                    fontSize={styles.aceEditor.fontSize}
+                    wrapEnabled={false}
+                    onChange={content => this.props.onChange(this.props.id, content)}
+                    onFocus={() => this.setState({ isFocused: true })}
+                    onBlur={() => this.setState({ isFocused: false })}
+                    value={this.props.value}
+                    showPrintMargin={false}
+                    highlightActiveLine={this.state.isFocused}
+                    showGutter={false}
+                    width="100%"
+                    height={200}
+                    tabSize={3}
+                    useSoftTabs="true"
+                    editorProps={{
+                        $blockScrolling: Infinity,
+                        display_indent_guides: true,
+                        folding: "markbeginandend"
+                    }}
+                    setOptions={{
+                        cursorStyle: "smooth",
+                        wrapBehavioursEnabled: true
+                    }}
+                />
+            </div>
+        );
+    }
+}
+
+export default CodeProperty;

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/TextProperty.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/TextProperty.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/TextProperty.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/inputTypes/TextProperty.jsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -46,10 +46,11 @@ class TextProperty extends React.Component {
                 id={this.props.id}
                 name={this.props.id}
                 floatingLabelText={(this.props.fieldName) ? (this.props.fieldName) : (null)}
-                type={(this.props.number) ? ('number') : ('text')}
+                type={this.props.number ? 'number' : 'text'}
                 value={this.props.value}
                 onChange={e => this.props.onChange(this.props.id, this.convertValue(e.target.value))}
-                fullWidth={(this.props.fullWidth)}
+                fullWidth={this.props.fullWidth}
+                multiLine={this.props.multiline}
                 style={(this.props.fullWidth) ? (null) : ({ width: this.props.width })}
             />
         );

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/utils/Types.js
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/utils/Types.js
@@ -55,6 +55,15 @@ const Types = {
     chartStacking: {
         stacked: 'stacked',
     },
+    // Provider configuration input fields
+    inputFields: {
+        TEXT_FIELD: 'TEXT_FIELD',
+        TEXT_AREA: 'TEXT_AREA',
+        NUMBER: 'NUMBER',
+        SWITCH: 'SWITCH',
+        SQL_CODE: 'SQL_CODE',
+        SIDDHI_CODE: 'SIDDHI_CODE'
+    }
 };
 
 export default Types;

--- a/components/dashboards-web-component/src/gadgets-generation-wizard/utils/UtilFunctions.js
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/utils/UtilFunctions.js
@@ -74,6 +74,25 @@ class UtilFunctions {
         }
     }
 
+    /**
+     * Returns default render types of pre-configured H2 datasource
+     * @returns {{}}
+     */
+    static getDefaultH2RenderTypes() {
+        return {
+            "datasourceName": "TEXT_FIELD",
+            "query": "SQL_CODE",
+            "tableName": "TEXT_FIELD",
+            "incrementalColumn": "TEXT_FIELD",
+            "timeColumns": "TEXT_FIELD",
+            "publishingInterval": 'NUMBER',
+            "purgingInterval": 'NUMBER',
+            "publishingLimit": 'NUMBER',
+            "purgingLimit": 'NUMBER',
+            "isPurgingEnable": 'SWITCH'
+        }
+    }
+
     /* Chart Validation & Preparation functions [START] */
 
     /**


### PR DESCRIPTION
## Purpose
> - Implementing render input fields based on the API response
> - Introducing `CodeProperty` for SQL & Siddhi query related fields

## Goals
> - Rendering input fields based on given configuration types, rather than checking the values of them

## Approach
![image](https://user-images.githubusercontent.com/24828296/36149443-b9c485ee-10e5-11e8-9a11-6af2fce64689.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-analytics/pull/1160