### PR TITLE
Upgrade react-Vizgrammer version to 0.6.18

### DIFF
--- a/components/dashboards-web-component/package-lock.json
+++ b/components/dashboards-web-component/package-lock.json
@@ -1147,6 +1147,11 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.1.tgz",
       "integrity": "sha512-UXti1JB6oK8hO983AImunnV6j/fqAEeDlPXh99zhsP5g32oLbxJJ6qcOaUesR+tqqhnUVQHlRJyD0dfiV0Hxaw=="
     },
+    "brace": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/brace/-/brace-0.11.1.tgz",
+      "integrity": "sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg="
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1783,16 +1788,6 @@
         "sha.js": "2.4.9"
       }
     },
-    "create-react-class": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -1968,9 +1963,9 @@
       }
     },
     "d3": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-4.12.0.tgz",
-      "integrity": "sha512-ibAzFJrj1uuX+wIy29baTx9JebA5i670UKlp+H3c9pg0w8PKl8jpj4zf64MmLPVBXm2vA1i29obnWuM/rmyfWA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
+      "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
       "requires": {
         "d3-array": "1.2.1",
         "d3-axis": "1.0.8",
@@ -1983,8 +1978,8 @@
         "d3-dsv": "1.0.8",
         "d3-ease": "1.0.3",
         "d3-force": "1.1.0",
-        "d3-format": "1.2.1",
-        "d3-geo": "1.9.0",
+        "d3-format": "1.2.2",
+        "d3-geo": "1.9.1",
         "d3-hierarchy": "1.1.5",
         "d3-interpolate": "1.1.6",
         "d3-path": "1.0.5",
@@ -1994,7 +1989,7 @@
         "d3-random": "1.1.0",
         "d3-request": "1.0.6",
         "d3-scale": "1.0.7",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-shape": "1.2.0",
         "d3-time": "1.0.8",
         "d3-time-format": "2.1.1",
@@ -2004,6 +1999,11 @@
         "d3-zoom": "1.7.1"
       },
       "dependencies": {
+        "d3-format": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+          "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+        },
         "d3-scale": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
@@ -2012,7 +2012,7 @@
             "d3-array": "1.2.1",
             "d3-collection": "1.0.4",
             "d3-color": "1.0.3",
-            "d3-format": "1.2.1",
+            "d3-format": "1.2.2",
             "d3-interpolate": "1.1.6",
             "d3-time": "1.0.8",
             "d3-time-format": "2.1.1"
@@ -2038,7 +2038,7 @@
         "d3-dispatch": "1.0.3",
         "d3-drag": "1.2.1",
         "d3-interpolate": "1.1.6",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-transition": "1.1.1"
       }
     },
@@ -2072,7 +2072,7 @@
       "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
       "requires": {
         "d3-dispatch": "1.0.3",
-        "d3-selection": "1.2.0"
+        "d3-selection": "1.3.0"
       }
     },
     "d3-dsv": {
@@ -2107,9 +2107,9 @@
       "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w=="
     },
     "d3-geo": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.0.tgz",
-      "integrity": "sha512-94YbAT+q5E/p+XEd4VKiNkQNicrrON3l6eoW70sC8aHjUGoBDJ/Ht8Z/hvhGJJTi2zhYBvUd34Mfqv4TG7we9A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
+      "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
       "requires": {
         "d3-array": "1.2.1"
       }
@@ -2121,7 +2121,7 @@
       "requires": {
         "commander": "2.12.2",
         "d3-array": "1.2.1",
-        "d3-geo": "1.9.0"
+        "d3-geo": "1.9.1"
       }
     },
     "d3-hierarchy": {
@@ -2188,9 +2188,9 @@
       }
     },
     "d3-selection": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.2.0.tgz",
-      "integrity": "sha512-xW2Pfcdzh1gOaoI+LGpPsLR2VpBQxuFoxvrvguK8ZmrJbPIVvfNG6pU6GNfK41D6Qz15sj61sbW/AFYuukwaLQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+      "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
     },
     "d3-shape": {
       "version": "1.2.0",
@@ -2227,7 +2227,7 @@
         "d3-dispatch": "1.0.3",
         "d3-ease": "1.0.3",
         "d3-interpolate": "1.1.6",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-timer": "1.0.7"
       }
     },
@@ -2244,7 +2244,7 @@
         "d3-dispatch": "1.0.3",
         "d3-drag": "1.2.1",
         "d3-interpolate": "1.1.6",
-        "d3-selection": "1.2.0",
+        "d3-selection": "1.3.0",
         "d3-transition": "1.1.1"
       }
     },
@@ -2447,9 +2447,9 @@
       }
     },
     "dom-align": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.6.6.tgz",
-      "integrity": "sha512-yBCGmhzj6SRaeAJlFUK/iMDh6bBpQE7EuChyPnrV8LQFV3vo3XghZw2lgHgj/8o9USFunVlvJ6YXfQWVdGnV8Q=="
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.6.7.tgz",
+      "integrity": "sha512-FrHttKVCqdHaDyVjygY+8kRhcNOJEdvAkc2ltppJUz71ekgpzIOuLgsOIKVqzdETI2EocmW2DzF+uP365qcR5Q=="
     },
     "dom-helpers": {
       "version": "3.2.1",
@@ -4856,6 +4856,11 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -4865,6 +4870,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -6824,15 +6834,15 @@
       "integrity": "sha512-V1AN/gMNiJ3vOzbY/H3CTxhzYH+Ri2KlsEpo1SN8/SYmI4I/ZfQpScFAgmERuIGcLStA2sOEeBNVpH2FaOd2hA==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "dom-align": "1.6.6",
+        "dom-align": "1.6.7",
         "prop-types": "15.6.0",
-        "rc-util": "4.3.1"
+        "rc-util": "4.4.0"
       }
     },
     "rc-animate": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.1.tgz",
-      "integrity": "sha512-hixobyAvDv0Oz4gHPOh67K4ck5Rz3JBBojBuKzYcu4b8JKMIiJxym83DfkkkYxXEEx/rwGf0mU0Dno/lbWghIQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.4.tgz",
+      "integrity": "sha512-DjJLTUQj7XKKcuS8cczN0uOLfuSmgrVXFGieP1SZc87xUUTFGh8B/KjNmEtlfvxkSrSuVfb2rrEPER4SqKUtEA==",
       "requires": {
         "babel-runtime": "6.26.0",
         "css-animation": "1.4.1",
@@ -6840,15 +6850,15 @@
       }
     },
     "rc-slider": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.5.0.tgz",
-      "integrity": "sha512-dw1kA7Dr6GOmPZFsy+yMxVyqmckeUtYVdfNOdQcI9O8mXkoCwlxXolMK9bW/TTlXCc8ztaXkJkyTVXl/Gkg5Tw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.6.0.tgz",
+      "integrity": "sha512-Ek68lWlMZm2b9N0AevvBvd/1GRG+n/kvf2wpvSz4xkXawc2SXpF64auU2qF6eyvv98qhGFoDeyCELMATYddJkA==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "prop-types": "15.6.0",
         "rc-tooltip": "3.7.0",
-        "rc-util": "4.3.1",
+        "rc-util": "4.4.0",
         "shallowequal": "1.0.2",
         "warning": "3.0.0"
       }
@@ -6860,26 +6870,25 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "prop-types": "15.6.0",
-        "rc-trigger": "2.3.3"
+        "rc-trigger": "2.3.4"
       }
     },
     "rc-trigger": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.3.tgz",
-      "integrity": "sha512-j8MHq0jES4vXShFbSExyty/WVR238lrZzUfsSaIDeiziBIiUAOP6SR2HBEi2gSGK239Jm3bWIJvwGA85kFMgmQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.4.tgz",
+      "integrity": "sha512-xPhda3SfGWHywEbVJu2VxpWg99ELStzNPcdnxb7lZ9XwUnHjUeX9KCaIbJa9GUuoVHx3mQP1s2m3ttIB8aashQ==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "create-react-class": "15.6.2",
         "prop-types": "15.6.0",
         "rc-align": "2.3.5",
-        "rc-animate": "2.4.1",
-        "rc-util": "4.3.1"
+        "rc-animate": "2.4.4",
+        "rc-util": "4.4.0"
       }
     },
     "rc-util": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.3.1.tgz",
-      "integrity": "sha512-OVNMKLePnwn0dCX/Gpc+/kGEDpmMo1Rfesg9xFcAckRd+D+YwVqV+dUJMHugP+4nRtbXi55o0HwPlkKIApYfQA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.4.0.tgz",
+      "integrity": "sha512-PIWw9VBjLc2m4GZBPxMFT3QaOIMQ0PdzMjAs02nQ3RSPDt6oLzZ+rMBzN1AxcNkkpBbz0Zmdg3llZGzYraWFew==",
       "requires": {
         "add-dom-event-listener": "1.0.2",
         "babel-runtime": "6.26.0",
@@ -6905,6 +6914,17 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-ace": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-5.9.0.tgz",
+      "integrity": "sha512-r6Tuce6seG05g9kT2Tio6DWohy06knG7e5u9OfhvMquZL+Cyu4eqPf60K1Vi2RXlS3+FWrdG8Rinwu4+oQjjgw==",
+      "requires": {
+        "brace": "0.11.1",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
         "prop-types": "15.6.0"
       }
     },
@@ -7091,9 +7111,9 @@
       }
     },
     "react-table": {
-      "version": "6.7.5",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.7.5.tgz",
-      "integrity": "sha1-l0sm45hpMubHJPU5Ee3fo5I7eUI=",
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.7.6.tgz",
+      "integrity": "sha1-P547MIMozrBO+TpHur76uiYZyQU=",
       "requires": {
         "classnames": "2.2.5"
       }
@@ -7120,21 +7140,22 @@
       }
     },
     "react-vizgrammar": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.9.tgz",
-      "integrity": "sha512-pOs99ERM5HJs0ieSx4NfD7arYehxylPoXt7N+iOio/cxD+B1azN1+FDtG4ZH1UBdrdRuu1V2EA/UczwcesE81g==",
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+      "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
       "requires": {
-        "d3": "4.12.0",
+        "d3": "4.13.0",
+        "lodash": "4.17.4",
         "prop-types": "15.6.0",
-        "rc-slider": "8.5.0",
+        "rc-slider": "8.6.0",
         "react": "16.1.1",
         "react-dom": "16.1.1",
         "react-simple-maps": "0.9.0",
-        "react-table": "6.7.5",
+        "react-table": "6.7.6",
         "react-tooltip": "3.4.0",
         "topojson-client": "3.0.0",
         "victory": "0.22.2",
-        "victory-core": "20.3.0"
+        "victory-core": "20.6.0"
       }
     },
     "reactcss": {
@@ -8780,9 +8801,9 @@
       }
     },
     "victory-core": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-      "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+      "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
       "requires": {
         "d3-ease": "1.0.3",
         "d3-interpolate": "1.1.6",

--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -36,7 +36,7 @@
     "react-router-dom": "^4.1.2",
     "react-shadow": "^2.0.2",
     "react-tooltip": "^3.4.0",
-    "react-vizgrammar": "^0.6.7",
+    "react-vizgrammar": "^0.6.18",
     "recharts": "^1.0.0-alpha.2",
     "rimraf": "^2.6.2",
     "style-loader": "^0.18.2",

--- a/samples/widgets/CpuUsage/package-lock.json
+++ b/samples/widgets/CpuUsage/package-lock.json
@@ -67,6 +67,12 @@
         "repeat-string": "1.6.1"
       }
     },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -109,6 +115,15 @@
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.3"
+      }
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -201,6 +216,20 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "autoprefixer": {
+      "version": "6.7.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000808",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -1028,6 +1057,16 @@
         "pako": "1.0.6"
       }
     },
+    "browserslist": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+      "dev": true,
+      "requires": {
+        "caniuse-db": "1.0.30000808",
+        "electron-to-chromium": "1.3.33"
+      }
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1072,6 +1111,24 @@
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
       }
+    },
+    "caniuse-api": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000808",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30000808",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+      "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
+      "dev": true
     },
     "caseless": {
       "version": "0.11.0",
@@ -1159,6 +1216,15 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "clap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
+    },
     "classnames": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -1175,6 +1241,12 @@
         "strip-ansi": "3.0.1",
         "wrap-ansi": "2.1.0"
       }
+    },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "dev": true
     },
     "clone-deep": {
       "version": "0.3.0",
@@ -1194,10 +1266,71 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "coa": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "dev": true,
+      "requires": {
+        "q": "1.5.1"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.3",
+        "color-convert": "1.9.1",
+        "color-string": "0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "colormin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+      "dev": true,
+      "requires": {
+        "color": "0.11.4",
+        "css-color-names": "0.0.4",
+        "has": "1.0.1"
+      }
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "combined-stream": {
@@ -1366,6 +1499,114 @@
         "randomfill": "1.0.3"
       }
     },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "dev": true
+    },
+    "css-loader": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.9.tgz",
+      "integrity": "sha512-r3dgelMm/mkPz5Y7m9SeiGE46i2VsEU/OYbez+1llfxtv8b2y5/b5StaeEvPK3S5tlNQI+tDW/xDIhKJoZgDtw==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "icss-utils": "2.1.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.2.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "postcss-value-parser": "3.3.0",
+        "source-list-map": "2.0.0"
+      }
+    },
+    "css-selector-tokenizer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+      "dev": true,
+      "requires": {
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        }
+      }
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
+      }
+    },
+    "csso": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+      "dev": true,
+      "requires": {
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1500,6 +1741,12 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1563,6 +1810,12 @@
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+      "dev": true
     },
     "elliptic": {
       "version": "6.4.0",
@@ -1711,6 +1964,12 @@
         "estraverse": "4.2.0"
       }
     },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
@@ -1846,6 +2105,12 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
+    "fastparse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+      "dev": true
+    },
     "fbjs": {
       "version": "0.8.16",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
@@ -1910,6 +2175,12 @@
         "locate-path": "2.0.0"
       }
     },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+      "dev": true
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1958,6 +2229,12 @@
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2"
       }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -2135,6 +2412,15 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2220,6 +2506,12 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "html-comment-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+      "dev": true
+    },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -2242,6 +2534,75 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+      "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.17"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
@@ -2262,6 +2623,12 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
     },
     "indexof": {
       "version": "0.0.1",
@@ -2302,6 +2669,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
     "is-arrayish": {
@@ -2409,6 +2782,12 @@
         "kind-of": "3.2.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2440,6 +2819,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-svg": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "1.1.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2496,6 +2884,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "js-yaml": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -2650,10 +3048,22 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.mergewith": {
@@ -2666,6 +3076,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "longest": {
@@ -2701,6 +3117,12 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
+    },
+    "macaddress": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+      "dev": true
     },
     "make-dir": {
       "version": "1.1.0",
@@ -3050,6 +3472,24 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3070,6 +3510,12 @@
         "gauge": "2.7.4",
         "set-blocking": "2.0.0"
       }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -3323,6 +3769,580 @@
         "find-up": "2.1.0"
       }
     },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.3.2",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "postcss-calc": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
+      }
+    },
+    "postcss-colormin": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+      "dev": true,
+      "requires": {
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-convert-values": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-unused": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-filter-plugins": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqid": "4.1.1"
+      }
+    },
+    "postcss-merge-idents": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
+      }
+    },
+    "postcss-message-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+      "dev": true
+    },
+    "postcss-minify-font-values": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-params": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+      "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.17"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.17"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.17"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.17"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-reduce-idents": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "dev": true,
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
+    },
+    "postcss-svgo": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+      "dev": true,
+      "requires": {
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+      "dev": true
+    },
+    "postcss-zindex": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3396,11 +4416,27 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
     "qs": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
       "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
       "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -3879,6 +4915,21 @@
         "pify": "3.0.0"
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "schema-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.4.0"
+      }
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -3992,6 +5043,15 @@
         "hoek": "2.16.3"
       }
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -4032,6 +5092,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
@@ -4089,6 +5155,12 @@
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
@@ -4149,11 +5221,36 @@
         "get-stdin": "4.0.1"
       }
     },
+    "style-loader": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
+      "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0"
+      }
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
+    },
+    "svgo": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+      "dev": true,
+      "requires": {
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
+      }
     },
     "tapable": {
       "version": "0.2.8",
@@ -4322,6 +5419,27 @@
         "webpack-sources": "1.0.2"
       }
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uniqid": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+      "dev": true,
+      "requires": {
+        "macaddress": "0.2.8"
+      }
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
+    },
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4378,6 +5496,12 @@
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
+    },
+    "vendors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+      "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -4628,6 +5752,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
+    "whet.extend": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+      "dev": true
     },
     "which": {
       "version": "1.3.0",

--- a/samples/widgets/LoadAverage/package-lock.json
+++ b/samples/widgets/LoadAverage/package-lock.json
@@ -67,6 +67,12 @@
                 "repeat-string": "1.6.1"
             }
         },
+        "alphanum-sort": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+            "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+            "dev": true
+        },
         "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -109,6 +115,15 @@
             "requires": {
                 "delegates": "1.0.0",
                 "readable-stream": "2.3.3"
+            }
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -201,6 +216,20 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
+        },
+        "autoprefixer": {
+            "version": "6.7.7",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+            "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000808",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
         },
         "aws-sign2": {
             "version": "0.6.0",
@@ -1028,6 +1057,16 @@
                 "pako": "1.0.6"
             }
         },
+        "browserslist": {
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+            "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+            "dev": true,
+            "requires": {
+                "caniuse-db": "1.0.30000808",
+                "electron-to-chromium": "1.3.33"
+            }
+        },
         "buffer": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1072,6 +1111,24 @@
                 "camelcase": "2.1.1",
                 "map-obj": "1.0.1"
             }
+        },
+        "caniuse-api": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+            "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000808",
+                "lodash.memoize": "4.1.2",
+                "lodash.uniq": "4.5.0"
+            }
+        },
+        "caniuse-db": {
+            "version": "1.0.30000808",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+            "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
+            "dev": true
         },
         "caseless": {
             "version": "0.11.0",
@@ -1159,6 +1216,15 @@
                 "safe-buffer": "5.1.1"
             }
         },
+        "clap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3"
+            }
+        },
         "classnames": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -1175,6 +1241,12 @@
                 "strip-ansi": "3.0.1",
                 "wrap-ansi": "2.1.0"
             }
+        },
+        "clone": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+            "dev": true
         },
         "clone-deep": {
             "version": "0.3.0",
@@ -1194,10 +1266,71 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
+        "coa": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+            "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+            "dev": true,
+            "requires": {
+                "q": "1.5.1"
+            }
+        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "color": {
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+            "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+            "dev": true,
+            "requires": {
+                "clone": "1.0.3",
+                "color-convert": "1.9.1",
+                "color-string": "0.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-string": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+            "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "colormin": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+            "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+            "dev": true,
+            "requires": {
+                "color": "0.11.4",
+                "css-color-names": "0.0.4",
+                "has": "1.0.1"
+            }
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
             "dev": true
         },
         "combined-stream": {
@@ -1366,6 +1499,114 @@
                 "randomfill": "1.0.3"
             }
         },
+        "css-color-names": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+            "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+            "dev": true
+        },
+        "css-loader": {
+            "version": "0.28.9",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.9.tgz",
+            "integrity": "sha512-r3dgelMm/mkPz5Y7m9SeiGE46i2VsEU/OYbez+1llfxtv8b2y5/b5StaeEvPK3S5tlNQI+tDW/xDIhKJoZgDtw==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "css-selector-tokenizer": "0.7.0",
+                "cssnano": "3.10.0",
+                "icss-utils": "2.1.0",
+                "loader-utils": "1.1.0",
+                "lodash.camelcase": "4.3.0",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-modules-extract-imports": "1.2.0",
+                "postcss-modules-local-by-default": "1.2.0",
+                "postcss-modules-scope": "1.1.0",
+                "postcss-modules-values": "1.3.0",
+                "postcss-value-parser": "3.3.0",
+                "source-list-map": "2.0.0"
+            }
+        },
+        "css-selector-tokenizer": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+            "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+            "dev": true,
+            "requires": {
+                "cssesc": "0.1.0",
+                "fastparse": "1.1.1",
+                "regexpu-core": "1.0.0"
+            },
+            "dependencies": {
+                "regexpu-core": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                    "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "1.3.3",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
+                    }
+                }
+            }
+        },
+        "cssesc": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+            "dev": true
+        },
+        "cssnano": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+            "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+            "dev": true,
+            "requires": {
+                "autoprefixer": "6.7.7",
+                "decamelize": "1.2.0",
+                "defined": "1.0.0",
+                "has": "1.0.1",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-calc": "5.3.1",
+                "postcss-colormin": "2.2.2",
+                "postcss-convert-values": "2.6.1",
+                "postcss-discard-comments": "2.0.4",
+                "postcss-discard-duplicates": "2.1.0",
+                "postcss-discard-empty": "2.1.0",
+                "postcss-discard-overridden": "0.1.1",
+                "postcss-discard-unused": "2.2.3",
+                "postcss-filter-plugins": "2.0.2",
+                "postcss-merge-idents": "2.1.7",
+                "postcss-merge-longhand": "2.0.2",
+                "postcss-merge-rules": "2.1.2",
+                "postcss-minify-font-values": "1.0.5",
+                "postcss-minify-gradients": "1.0.5",
+                "postcss-minify-params": "1.2.2",
+                "postcss-minify-selectors": "2.1.1",
+                "postcss-normalize-charset": "1.1.1",
+                "postcss-normalize-url": "3.0.8",
+                "postcss-ordered-values": "2.2.3",
+                "postcss-reduce-idents": "2.4.0",
+                "postcss-reduce-initial": "1.0.1",
+                "postcss-reduce-transforms": "1.0.4",
+                "postcss-svgo": "2.1.6",
+                "postcss-unique-selectors": "2.0.2",
+                "postcss-value-parser": "3.3.0",
+                "postcss-zindex": "2.2.0"
+            }
+        },
+        "csso": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+            "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+            "dev": true,
+            "requires": {
+                "clap": "1.2.3",
+                "source-map": "0.5.7"
+            }
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1500,6 +1741,12 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1563,6 +1810,12 @@
             "requires": {
                 "jsbn": "0.1.1"
             }
+        },
+        "electron-to-chromium": {
+            "version": "1.3.33",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+            "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+            "dev": true
         },
         "elliptic": {
             "version": "6.4.0",
@@ -1711,6 +1964,12 @@
                 "estraverse": "4.2.0"
             }
         },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+            "dev": true
+        },
         "esrecurse": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
@@ -1846,6 +2105,12 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
+        "fastparse": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+            "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+            "dev": true
+        },
         "fbjs": {
             "version": "0.8.16",
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
@@ -1910,6 +2175,12 @@
                 "locate-path": "2.0.0"
             }
         },
+        "flatten": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+            "dev": true
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1958,6 +2229,12 @@
                 "mkdirp": "0.5.1",
                 "rimraf": "2.6.2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2135,6 +2412,15 @@
                 "pinkie-promise": "2.0.1"
             }
         },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2220,6 +2506,12 @@
             "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
             "dev": true
         },
+        "html-comment-regex": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+            "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+            "dev": true
+        },
         "http-signature": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -2242,6 +2534,75 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
             "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
+        "icss-replace-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+            "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+            "dev": true
+        },
+        "icss-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+            "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+            "dev": true,
+            "requires": {
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
         "ieee754": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
@@ -2262,6 +2623,12 @@
             "requires": {
                 "repeating": "2.0.1"
             }
+        },
+        "indexes-of": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+            "dev": true
         },
         "indexof": {
             "version": "0.0.1",
@@ -2302,6 +2669,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-absolute-url": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+            "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
             "dev": true
         },
         "is-arrayish": {
@@ -2409,6 +2782,12 @@
                 "kind-of": "3.2.2"
             }
         },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2440,6 +2819,15 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-svg": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+            "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+            "dev": true,
+            "requires": {
+                "html-comment-regex": "1.1.1"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -2496,6 +2884,16 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "js-yaml": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+            "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
+            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -2650,10 +3048,22 @@
             "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
             "dev": true
         },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+            "dev": true
+        },
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
         },
         "lodash.mergewith": {
@@ -2666,6 +3076,12 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+            "dev": true
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
             "dev": true
         },
         "longest": {
@@ -2701,6 +3117,12 @@
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
             }
+        },
+        "macaddress": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+            "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+            "dev": true
         },
         "make-dir": {
             "version": "1.1.0",
@@ -3050,6 +3472,24 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+            "dev": true
+        },
+        "normalize-url": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "prepend-http": "1.0.4",
+                "query-string": "4.3.4",
+                "sort-keys": "1.1.2"
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3070,6 +3510,12 @@
                 "gauge": "2.7.4",
                 "set-blocking": "2.0.0"
             }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+            "dev": true
         },
         "number-is-nan": {
             "version": "1.0.1",
@@ -3323,6 +3769,580 @@
                 "find-up": "2.1.0"
             }
         },
+        "postcss": {
+            "version": "5.2.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "js-base64": "2.3.2",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-calc": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+            "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.3.0"
+            }
+        },
+        "postcss-colormin": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+            "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+            "dev": true,
+            "requires": {
+                "colormin": "1.1.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-convert-values": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+            "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-discard-comments": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+            "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-duplicates": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+            "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-empty": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+            "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-overridden": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+            "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-unused": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+            "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-filter-plugins": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+            "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "uniqid": "4.1.1"
+            }
+        },
+        "postcss-merge-idents": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+            "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-merge-longhand": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+            "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-merge-rules": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+            "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-api": "1.6.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3",
+                "vendors": "1.0.1"
+            }
+        },
+        "postcss-message-helpers": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+            "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+            "dev": true
+        },
+        "postcss-minify-font-values": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+            "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-minify-gradients": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+            "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-minify-params": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+            "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-minify-selectors": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+            "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3"
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+            "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+            "dev": true,
+            "requires": {
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-local-by-default": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+            "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-scope": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+            "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-values": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+            "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+            "dev": true,
+            "requires": {
+                "icss-replace-symbols": "1.1.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-normalize-charset": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+            "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-normalize-url": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+            "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+            "dev": true,
+            "requires": {
+                "is-absolute-url": "2.1.0",
+                "normalize-url": "1.9.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-ordered-values": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+            "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-reduce-idents": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+            "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-reduce-initial": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+            "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-reduce-transforms": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+            "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+            "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+            "dev": true,
+            "requires": {
+                "flatten": "1.0.2",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+            }
+        },
+        "postcss-svgo": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+            "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+            "dev": true,
+            "requires": {
+                "is-svg": "2.1.0",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "svgo": "0.7.2"
+            }
+        },
+        "postcss-unique-selectors": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+            "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+            "dev": true
+        },
+        "postcss-zindex": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+            "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3396,11 +4416,27 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
         "qs": {
             "version": "6.3.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
             "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
             "dev": true
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
+            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -3879,6 +4915,21 @@
                 "pify": "3.0.0"
             }
         },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "schema-utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+            "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.4.0"
+            }
+        },
         "scss-tokenizer": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -3992,6 +5043,15 @@
                 "hoek": "2.16.3"
             }
         },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "1.1.0"
+            }
+        },
         "source-list-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -4032,6 +5092,12 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "sshpk": {
@@ -4089,6 +5155,12 @@
                 "to-arraybuffer": "1.0.1",
                 "xtend": "4.0.1"
             }
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
         },
         "string-width": {
             "version": "1.0.2",
@@ -4149,11 +5221,36 @@
                 "get-stdin": "4.0.1"
             }
         },
+        "style-loader": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
+            "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.3.0"
+            }
+        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
+        },
+        "svgo": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+            "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+            "dev": true,
+            "requires": {
+                "coa": "1.0.4",
+                "colors": "1.1.2",
+                "csso": "2.3.2",
+                "js-yaml": "3.7.0",
+                "mkdirp": "0.5.1",
+                "sax": "1.2.4",
+                "whet.extend": "0.9.9"
+            }
         },
         "tapable": {
             "version": "0.2.8",
@@ -4322,6 +5419,27 @@
                 "webpack-sources": "1.0.2"
             }
         },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "uniqid": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+            "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+            "dev": true,
+            "requires": {
+                "macaddress": "0.2.8"
+            }
+        },
+        "uniqs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+            "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+            "dev": true
+        },
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4378,6 +5496,12 @@
                 "spdx-correct": "1.0.2",
                 "spdx-expression-parse": "1.0.4"
             }
+        },
+        "vendors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+            "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -4628,6 +5752,12 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
             "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        },
+        "whet.extend": {
+            "version": "0.9.9",
+            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+            "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+            "dev": true
         },
         "which": {
             "version": "1.3.0",

--- a/samples/widgets/MemoryUsage/package-lock.json
+++ b/samples/widgets/MemoryUsage/package-lock.json
@@ -67,6 +67,12 @@
                 "repeat-string": "1.6.1"
             }
         },
+        "alphanum-sort": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+            "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+            "dev": true
+        },
         "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -109,6 +115,15 @@
             "requires": {
                 "delegates": "1.0.0",
                 "readable-stream": "2.3.3"
+            }
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -201,6 +216,20 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
+        },
+        "autoprefixer": {
+            "version": "6.7.7",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+            "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000808",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
         },
         "aws-sign2": {
             "version": "0.6.0",
@@ -1028,6 +1057,16 @@
                 "pako": "1.0.6"
             }
         },
+        "browserslist": {
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+            "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+            "dev": true,
+            "requires": {
+                "caniuse-db": "1.0.30000808",
+                "electron-to-chromium": "1.3.33"
+            }
+        },
         "buffer": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1072,6 +1111,24 @@
                 "camelcase": "2.1.1",
                 "map-obj": "1.0.1"
             }
+        },
+        "caniuse-api": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+            "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000808",
+                "lodash.memoize": "4.1.2",
+                "lodash.uniq": "4.5.0"
+            }
+        },
+        "caniuse-db": {
+            "version": "1.0.30000808",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+            "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
+            "dev": true
         },
         "caseless": {
             "version": "0.11.0",
@@ -1159,6 +1216,15 @@
                 "safe-buffer": "5.1.1"
             }
         },
+        "clap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3"
+            }
+        },
         "classnames": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -1175,6 +1241,12 @@
                 "strip-ansi": "3.0.1",
                 "wrap-ansi": "2.1.0"
             }
+        },
+        "clone": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+            "dev": true
         },
         "clone-deep": {
             "version": "0.3.0",
@@ -1194,10 +1266,71 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
+        "coa": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+            "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+            "dev": true,
+            "requires": {
+                "q": "1.5.1"
+            }
+        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "color": {
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+            "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+            "dev": true,
+            "requires": {
+                "clone": "1.0.3",
+                "color-convert": "1.9.1",
+                "color-string": "0.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-string": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+            "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "colormin": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+            "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+            "dev": true,
+            "requires": {
+                "color": "0.11.4",
+                "css-color-names": "0.0.4",
+                "has": "1.0.1"
+            }
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
             "dev": true
         },
         "combined-stream": {
@@ -1366,6 +1499,114 @@
                 "randomfill": "1.0.3"
             }
         },
+        "css-color-names": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+            "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+            "dev": true
+        },
+        "css-loader": {
+            "version": "0.28.9",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.9.tgz",
+            "integrity": "sha512-r3dgelMm/mkPz5Y7m9SeiGE46i2VsEU/OYbez+1llfxtv8b2y5/b5StaeEvPK3S5tlNQI+tDW/xDIhKJoZgDtw==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "css-selector-tokenizer": "0.7.0",
+                "cssnano": "3.10.0",
+                "icss-utils": "2.1.0",
+                "loader-utils": "1.1.0",
+                "lodash.camelcase": "4.3.0",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-modules-extract-imports": "1.2.0",
+                "postcss-modules-local-by-default": "1.2.0",
+                "postcss-modules-scope": "1.1.0",
+                "postcss-modules-values": "1.3.0",
+                "postcss-value-parser": "3.3.0",
+                "source-list-map": "2.0.0"
+            }
+        },
+        "css-selector-tokenizer": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+            "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+            "dev": true,
+            "requires": {
+                "cssesc": "0.1.0",
+                "fastparse": "1.1.1",
+                "regexpu-core": "1.0.0"
+            },
+            "dependencies": {
+                "regexpu-core": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                    "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "1.3.3",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
+                    }
+                }
+            }
+        },
+        "cssesc": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+            "dev": true
+        },
+        "cssnano": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+            "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+            "dev": true,
+            "requires": {
+                "autoprefixer": "6.7.7",
+                "decamelize": "1.2.0",
+                "defined": "1.0.0",
+                "has": "1.0.1",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-calc": "5.3.1",
+                "postcss-colormin": "2.2.2",
+                "postcss-convert-values": "2.6.1",
+                "postcss-discard-comments": "2.0.4",
+                "postcss-discard-duplicates": "2.1.0",
+                "postcss-discard-empty": "2.1.0",
+                "postcss-discard-overridden": "0.1.1",
+                "postcss-discard-unused": "2.2.3",
+                "postcss-filter-plugins": "2.0.2",
+                "postcss-merge-idents": "2.1.7",
+                "postcss-merge-longhand": "2.0.2",
+                "postcss-merge-rules": "2.1.2",
+                "postcss-minify-font-values": "1.0.5",
+                "postcss-minify-gradients": "1.0.5",
+                "postcss-minify-params": "1.2.2",
+                "postcss-minify-selectors": "2.1.1",
+                "postcss-normalize-charset": "1.1.1",
+                "postcss-normalize-url": "3.0.8",
+                "postcss-ordered-values": "2.2.3",
+                "postcss-reduce-idents": "2.4.0",
+                "postcss-reduce-initial": "1.0.1",
+                "postcss-reduce-transforms": "1.0.4",
+                "postcss-svgo": "2.1.6",
+                "postcss-unique-selectors": "2.0.2",
+                "postcss-value-parser": "3.3.0",
+                "postcss-zindex": "2.2.0"
+            }
+        },
+        "csso": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+            "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+            "dev": true,
+            "requires": {
+                "clap": "1.2.3",
+                "source-map": "0.5.7"
+            }
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1500,6 +1741,12 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1563,6 +1810,12 @@
             "requires": {
                 "jsbn": "0.1.1"
             }
+        },
+        "electron-to-chromium": {
+            "version": "1.3.33",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+            "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+            "dev": true
         },
         "elliptic": {
             "version": "6.4.0",
@@ -1711,6 +1964,12 @@
                 "estraverse": "4.2.0"
             }
         },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+            "dev": true
+        },
         "esrecurse": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
@@ -1846,6 +2105,12 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
+        "fastparse": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+            "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+            "dev": true
+        },
         "fbjs": {
             "version": "0.8.16",
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
@@ -1910,6 +2175,12 @@
                 "locate-path": "2.0.0"
             }
         },
+        "flatten": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+            "dev": true
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1958,6 +2229,12 @@
                 "mkdirp": "0.5.1",
                 "rimraf": "2.6.2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2135,6 +2412,15 @@
                 "pinkie-promise": "2.0.1"
             }
         },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2220,6 +2506,12 @@
             "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
             "dev": true
         },
+        "html-comment-regex": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+            "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+            "dev": true
+        },
         "http-signature": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -2242,6 +2534,75 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
             "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
+        "icss-replace-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+            "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+            "dev": true
+        },
+        "icss-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+            "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+            "dev": true,
+            "requires": {
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
         "ieee754": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
@@ -2262,6 +2623,12 @@
             "requires": {
                 "repeating": "2.0.1"
             }
+        },
+        "indexes-of": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+            "dev": true
         },
         "indexof": {
             "version": "0.0.1",
@@ -2302,6 +2669,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-absolute-url": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+            "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
             "dev": true
         },
         "is-arrayish": {
@@ -2409,6 +2782,12 @@
                 "kind-of": "3.2.2"
             }
         },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2440,6 +2819,15 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-svg": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+            "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+            "dev": true,
+            "requires": {
+                "html-comment-regex": "1.1.1"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -2496,6 +2884,16 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "js-yaml": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+            "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
+            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -2650,10 +3048,22 @@
             "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
             "dev": true
         },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+            "dev": true
+        },
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
         },
         "lodash.mergewith": {
@@ -2666,6 +3076,12 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+            "dev": true
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
             "dev": true
         },
         "longest": {
@@ -2701,6 +3117,12 @@
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
             }
+        },
+        "macaddress": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+            "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+            "dev": true
         },
         "make-dir": {
             "version": "1.1.0",
@@ -3050,6 +3472,24 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+            "dev": true
+        },
+        "normalize-url": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "prepend-http": "1.0.4",
+                "query-string": "4.3.4",
+                "sort-keys": "1.1.2"
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3070,6 +3510,12 @@
                 "gauge": "2.7.4",
                 "set-blocking": "2.0.0"
             }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+            "dev": true
         },
         "number-is-nan": {
             "version": "1.0.1",
@@ -3323,6 +3769,580 @@
                 "find-up": "2.1.0"
             }
         },
+        "postcss": {
+            "version": "5.2.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "js-base64": "2.3.2",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-calc": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+            "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.3.0"
+            }
+        },
+        "postcss-colormin": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+            "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+            "dev": true,
+            "requires": {
+                "colormin": "1.1.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-convert-values": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+            "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-discard-comments": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+            "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-duplicates": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+            "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-empty": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+            "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-overridden": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+            "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-unused": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+            "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-filter-plugins": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+            "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "uniqid": "4.1.1"
+            }
+        },
+        "postcss-merge-idents": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+            "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-merge-longhand": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+            "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-merge-rules": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+            "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-api": "1.6.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3",
+                "vendors": "1.0.1"
+            }
+        },
+        "postcss-message-helpers": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+            "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+            "dev": true
+        },
+        "postcss-minify-font-values": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+            "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-minify-gradients": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+            "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-minify-params": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+            "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-minify-selectors": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+            "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3"
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+            "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+            "dev": true,
+            "requires": {
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-local-by-default": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+            "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-scope": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+            "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-values": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+            "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+            "dev": true,
+            "requires": {
+                "icss-replace-symbols": "1.1.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-normalize-charset": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+            "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-normalize-url": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+            "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+            "dev": true,
+            "requires": {
+                "is-absolute-url": "2.1.0",
+                "normalize-url": "1.9.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-ordered-values": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+            "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-reduce-idents": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+            "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-reduce-initial": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+            "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-reduce-transforms": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+            "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+            "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+            "dev": true,
+            "requires": {
+                "flatten": "1.0.2",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+            }
+        },
+        "postcss-svgo": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+            "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+            "dev": true,
+            "requires": {
+                "is-svg": "2.1.0",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "svgo": "0.7.2"
+            }
+        },
+        "postcss-unique-selectors": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+            "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+            "dev": true
+        },
+        "postcss-zindex": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+            "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3396,11 +4416,27 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
         "qs": {
             "version": "6.3.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
             "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
             "dev": true
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
+            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -3879,6 +4915,21 @@
                 "pify": "3.0.0"
             }
         },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "schema-utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+            "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.4.0"
+            }
+        },
         "scss-tokenizer": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -3992,6 +5043,15 @@
                 "hoek": "2.16.3"
             }
         },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "1.1.0"
+            }
+        },
         "source-list-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -4032,6 +5092,12 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "sshpk": {
@@ -4089,6 +5155,12 @@
                 "to-arraybuffer": "1.0.1",
                 "xtend": "4.0.1"
             }
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
         },
         "string-width": {
             "version": "1.0.2",
@@ -4149,11 +5221,36 @@
                 "get-stdin": "4.0.1"
             }
         },
+        "style-loader": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
+            "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.3.0"
+            }
+        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
+        },
+        "svgo": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+            "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+            "dev": true,
+            "requires": {
+                "coa": "1.0.4",
+                "colors": "1.1.2",
+                "csso": "2.3.2",
+                "js-yaml": "3.7.0",
+                "mkdirp": "0.5.1",
+                "sax": "1.2.4",
+                "whet.extend": "0.9.9"
+            }
         },
         "tapable": {
             "version": "0.2.8",
@@ -4322,6 +5419,27 @@
                 "webpack-sources": "1.0.2"
             }
         },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "uniqid": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+            "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+            "dev": true,
+            "requires": {
+                "macaddress": "0.2.8"
+            }
+        },
+        "uniqs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+            "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+            "dev": true
+        },
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4378,6 +5496,12 @@
                 "spdx-correct": "1.0.2",
                 "spdx-expression-parse": "1.0.4"
             }
+        },
+        "vendors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+            "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -4628,6 +5752,12 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
             "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        },
+        "whet.extend": {
+            "version": "0.9.9",
+            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+            "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+            "dev": true
         },
         "which": {
             "version": "1.3.0",

--- a/samples/widgets/Publisher/package-lock.json
+++ b/samples/widgets/Publisher/package-lock.json
@@ -807,7 +807,6 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "dev": true,
             "requires": {
                 "core-js": "2.5.1",
                 "regenerator-runtime": "0.11.0"
@@ -816,8 +815,7 @@
                 "core-js": {
                     "version": "2.5.1",
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-                    "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-                    "dev": true
+                    "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
                 }
             }
         },
@@ -931,6 +929,11 @@
             "requires": {
                 "hoek": "2.16.3"
             }
+        },
+        "bowser": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.2.tgz",
+            "integrity": "sha512-fuiANC1Bqbqa/S4gmvfCt7bGBmNELMsGZj4Wg3PrP6esP66Ttoj1JSlzFlXtHyduMv07kDNmDsX6VsMWT/MLGg=="
         },
         "brace-expansion": {
             "version": "1.1.8",
@@ -1100,8 +1103,7 @@
         "chain-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-            "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w=",
-            "dev": true
+            "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
         },
         "chalk": {
             "version": "1.1.3",
@@ -1115,6 +1117,11 @@
                 "strip-ansi": "3.0.1",
                 "supports-color": "2.0.0"
             }
+        },
+        "change-emitter": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+            "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
         },
         "chokidar": {
             "version": "1.7.0",
@@ -1366,6 +1373,14 @@
                 "randomfill": "1.0.3"
             }
         },
+        "css-in-js-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
+            "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
+            "requires": {
+                "hyphenate-style-name": "1.0.2"
+            }
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1545,8 +1560,7 @@
         "dom-helpers": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
-            "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo=",
-            "dev": true
+            "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
         },
         "domain-browser": {
             "version": "1.1.7",
@@ -2204,6 +2218,11 @@
             "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
             "dev": true
         },
+        "hoist-non-react-statics": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+            "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+        },
         "home-or-tmp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -2236,6 +2255,11 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
+        },
+        "hyphenate-style-name": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+            "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
         },
         "iconv-lite": {
             "version": "0.4.19",
@@ -2282,6 +2306,15 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "inline-style-prefixer": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+            "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+            "requires": {
+                "bowser": "1.9.2",
+                "css-in-js-utils": "2.0.0"
+            }
         },
         "interpret": {
             "version": "1.0.4",
@@ -2566,6 +2599,11 @@
                 }
             }
         },
+        "keycode": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
+            "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
+        },
         "kind-of": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2656,6 +2694,11 @@
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
+        "lodash.merge": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+        },
         "lodash.mergewith": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
@@ -2667,6 +2710,11 @@
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
             "dev": true
+        },
+        "lodash.throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
         },
         "longest": {
             "version": "1.0.1",
@@ -2716,6 +2764,38 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
+        },
+        "material-ui": {
+            "version": "0.19.4",
+            "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.19.4.tgz",
+            "integrity": "sha1-ypzcqKqLtZTfrF2zjsn/BFoyNYc=",
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "inline-style-prefixer": "3.0.8",
+                "keycode": "2.1.9",
+                "lodash.merge": "4.6.1",
+                "lodash.throttle": "4.1.1",
+                "prop-types": "15.6.0",
+                "react-event-listener": "0.5.3",
+                "react-transition-group": "1.2.1",
+                "recompose": "0.26.0",
+                "simple-assign": "0.1.0",
+                "warning": "3.0.0"
+            },
+            "dependencies": {
+                "react-transition-group": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+                    "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+                    "requires": {
+                        "chain-function": "1.0.0",
+                        "dom-helpers": "3.2.1",
+                        "loose-envify": "1.3.1",
+                        "prop-types": "15.6.0",
+                        "warning": "3.0.0"
+                    }
+                }
+            }
         },
         "math-expression-evaluator": {
             "version": "1.2.17",
@@ -3505,6 +3585,17 @@
                 "prop-types": "15.6.0"
             }
         },
+        "react-event-listener": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
+            "integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "fbjs": "0.8.16",
+                "prop-types": "15.6.0",
+                "warning": "3.0.0"
+            }
+        },
         "react-resize-detector": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-1.1.0.tgz",
@@ -3642,6 +3733,17 @@
             "integrity": "sha1-2sdiFxSkdl0VLLKtvDDHO4MSCMk=",
             "dev": true
         },
+        "recompose": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+            "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+            "requires": {
+                "change-emitter": "0.1.6",
+                "fbjs": "0.8.16",
+                "hoist-non-react-statics": "2.3.1",
+                "symbol-observable": "1.2.0"
+            }
+        },
         "redent": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -3697,8 +3799,7 @@
         "regenerator-runtime": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-            "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-            "dev": true
+            "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         },
         "regenerator-transform": {
             "version": "0.10.1",
@@ -3977,6 +4078,11 @@
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
+        "simple-assign": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
+            "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
+        },
         "slash": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -4154,6 +4260,11 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
+        },
+        "symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
         },
         "tapable": {
             "version": "0.2.8",
@@ -4411,7 +4522,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
             "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-            "dev": true,
             "requires": {
                 "loose-envify": "1.3.1"
             }

--- a/samples/widgets/Subscriber/package-lock.json
+++ b/samples/widgets/Subscriber/package-lock.json
@@ -807,7 +807,6 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "dev": true,
             "requires": {
                 "core-js": "2.5.1",
                 "regenerator-runtime": "0.11.0"
@@ -816,8 +815,7 @@
                 "core-js": {
                     "version": "2.5.1",
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-                    "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-                    "dev": true
+                    "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
                 }
             }
         },
@@ -931,6 +929,11 @@
             "requires": {
                 "hoek": "2.16.3"
             }
+        },
+        "bowser": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.2.tgz",
+            "integrity": "sha512-fuiANC1Bqbqa/S4gmvfCt7bGBmNELMsGZj4Wg3PrP6esP66Ttoj1JSlzFlXtHyduMv07kDNmDsX6VsMWT/MLGg=="
         },
         "brace-expansion": {
             "version": "1.1.8",
@@ -1100,8 +1103,7 @@
         "chain-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-            "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w=",
-            "dev": true
+            "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
         },
         "chalk": {
             "version": "1.1.3",
@@ -1115,6 +1117,11 @@
                 "strip-ansi": "3.0.1",
                 "supports-color": "2.0.0"
             }
+        },
+        "change-emitter": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+            "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
         },
         "chokidar": {
             "version": "1.7.0",
@@ -1366,6 +1373,14 @@
                 "randomfill": "1.0.3"
             }
         },
+        "css-in-js-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
+            "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
+            "requires": {
+                "hyphenate-style-name": "1.0.2"
+            }
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1545,8 +1560,7 @@
         "dom-helpers": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
-            "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo=",
-            "dev": true
+            "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
         },
         "domain-browser": {
             "version": "1.1.7",
@@ -2204,6 +2218,11 @@
             "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
             "dev": true
         },
+        "hoist-non-react-statics": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+            "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+        },
         "home-or-tmp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -2236,6 +2255,11 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
+        },
+        "hyphenate-style-name": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+            "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
         },
         "iconv-lite": {
             "version": "0.4.19",
@@ -2282,6 +2306,15 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "inline-style-prefixer": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+            "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+            "requires": {
+                "bowser": "1.9.2",
+                "css-in-js-utils": "2.0.0"
+            }
         },
         "interpret": {
             "version": "1.0.4",
@@ -2566,6 +2599,11 @@
                 }
             }
         },
+        "keycode": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
+            "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
+        },
         "kind-of": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2656,6 +2694,11 @@
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
+        "lodash.merge": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+        },
         "lodash.mergewith": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
@@ -2667,6 +2710,11 @@
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
             "dev": true
+        },
+        "lodash.throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
         },
         "longest": {
             "version": "1.0.1",
@@ -2716,6 +2764,38 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
+        },
+        "material-ui": {
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.20.0.tgz",
+            "integrity": "sha512-wkHkeU1SaGfCrtwIzBOl5vynNNNzVGW27ql0Ue5HZLB4WyRQ3YohJBdKa5lBrH5JD/Cgae7IzrP7cVWDyKpeLQ==",
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "inline-style-prefixer": "3.0.8",
+                "keycode": "2.1.9",
+                "lodash.merge": "4.6.1",
+                "lodash.throttle": "4.1.1",
+                "prop-types": "15.6.0",
+                "react-event-listener": "0.5.3",
+                "react-transition-group": "1.2.1",
+                "recompose": "0.26.0",
+                "simple-assign": "0.1.0",
+                "warning": "3.0.0"
+            },
+            "dependencies": {
+                "react-transition-group": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+                    "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+                    "requires": {
+                        "chain-function": "1.0.0",
+                        "dom-helpers": "3.2.1",
+                        "loose-envify": "1.3.1",
+                        "prop-types": "15.6.0",
+                        "warning": "3.0.0"
+                    }
+                }
+            }
         },
         "math-expression-evaluator": {
             "version": "1.2.17",
@@ -3505,6 +3585,17 @@
                 "prop-types": "15.6.0"
             }
         },
+        "react-event-listener": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
+            "integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "fbjs": "0.8.16",
+                "prop-types": "15.6.0",
+                "warning": "3.0.0"
+            }
+        },
         "react-resize-detector": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-1.1.0.tgz",
@@ -3642,6 +3733,17 @@
             "integrity": "sha1-2sdiFxSkdl0VLLKtvDDHO4MSCMk=",
             "dev": true
         },
+        "recompose": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+            "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+            "requires": {
+                "change-emitter": "0.1.6",
+                "fbjs": "0.8.16",
+                "hoist-non-react-statics": "2.3.1",
+                "symbol-observable": "1.2.0"
+            }
+        },
         "redent": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -3697,8 +3799,7 @@
         "regenerator-runtime": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-            "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-            "dev": true
+            "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         },
         "regenerator-transform": {
             "version": "0.10.1",
@@ -3977,6 +4078,11 @@
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
+        "simple-assign": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
+            "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
+        },
         "slash": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -4154,6 +4260,11 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
+        },
+        "symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
         },
         "tapable": {
             "version": "0.2.8",
@@ -4411,7 +4522,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
             "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-            "dev": true,
             "requires": {
                 "loose-envify": "1.3.1"
             }

--- a/samples/widgets/TotalUpdates/package-lock.json
+++ b/samples/widgets/TotalUpdates/package-lock.json
@@ -67,6 +67,12 @@
                 "repeat-string": "1.6.1"
             }
         },
+        "alphanum-sort": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+            "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+            "dev": true
+        },
         "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -109,6 +115,15 @@
             "requires": {
                 "delegates": "1.0.0",
                 "readable-stream": "2.3.3"
+            }
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -201,6 +216,20 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
+        },
+        "autoprefixer": {
+            "version": "6.7.7",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+            "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000808",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
         },
         "aws-sign2": {
             "version": "0.6.0",
@@ -1028,6 +1057,16 @@
                 "pako": "1.0.6"
             }
         },
+        "browserslist": {
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+            "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+            "dev": true,
+            "requires": {
+                "caniuse-db": "1.0.30000808",
+                "electron-to-chromium": "1.3.33"
+            }
+        },
         "buffer": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1072,6 +1111,24 @@
                 "camelcase": "2.1.1",
                 "map-obj": "1.0.1"
             }
+        },
+        "caniuse-api": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+            "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-db": "1.0.30000808",
+                "lodash.memoize": "4.1.2",
+                "lodash.uniq": "4.5.0"
+            }
+        },
+        "caniuse-db": {
+            "version": "1.0.30000808",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+            "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
+            "dev": true
         },
         "caseless": {
             "version": "0.11.0",
@@ -1159,6 +1216,15 @@
                 "safe-buffer": "5.1.1"
             }
         },
+        "clap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3"
+            }
+        },
         "classnames": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -1175,6 +1241,12 @@
                 "strip-ansi": "3.0.1",
                 "wrap-ansi": "2.1.0"
             }
+        },
+        "clone": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+            "dev": true
         },
         "clone-deep": {
             "version": "0.3.0",
@@ -1194,10 +1266,71 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
+        "coa": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+            "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+            "dev": true,
+            "requires": {
+                "q": "1.5.1"
+            }
+        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "color": {
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+            "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+            "dev": true,
+            "requires": {
+                "clone": "1.0.3",
+                "color-convert": "1.9.1",
+                "color-string": "0.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-string": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+            "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "colormin": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+            "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+            "dev": true,
+            "requires": {
+                "color": "0.11.4",
+                "css-color-names": "0.0.4",
+                "has": "1.0.1"
+            }
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
             "dev": true
         },
         "combined-stream": {
@@ -1366,6 +1499,114 @@
                 "randomfill": "1.0.3"
             }
         },
+        "css-color-names": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+            "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+            "dev": true
+        },
+        "css-loader": {
+            "version": "0.28.9",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.9.tgz",
+            "integrity": "sha512-r3dgelMm/mkPz5Y7m9SeiGE46i2VsEU/OYbez+1llfxtv8b2y5/b5StaeEvPK3S5tlNQI+tDW/xDIhKJoZgDtw==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "css-selector-tokenizer": "0.7.0",
+                "cssnano": "3.10.0",
+                "icss-utils": "2.1.0",
+                "loader-utils": "1.1.0",
+                "lodash.camelcase": "4.3.0",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-modules-extract-imports": "1.2.0",
+                "postcss-modules-local-by-default": "1.2.0",
+                "postcss-modules-scope": "1.1.0",
+                "postcss-modules-values": "1.3.0",
+                "postcss-value-parser": "3.3.0",
+                "source-list-map": "2.0.0"
+            }
+        },
+        "css-selector-tokenizer": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+            "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+            "dev": true,
+            "requires": {
+                "cssesc": "0.1.0",
+                "fastparse": "1.1.1",
+                "regexpu-core": "1.0.0"
+            },
+            "dependencies": {
+                "regexpu-core": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                    "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "1.3.3",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
+                    }
+                }
+            }
+        },
+        "cssesc": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+            "dev": true
+        },
+        "cssnano": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+            "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+            "dev": true,
+            "requires": {
+                "autoprefixer": "6.7.7",
+                "decamelize": "1.2.0",
+                "defined": "1.0.0",
+                "has": "1.0.1",
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-calc": "5.3.1",
+                "postcss-colormin": "2.2.2",
+                "postcss-convert-values": "2.6.1",
+                "postcss-discard-comments": "2.0.4",
+                "postcss-discard-duplicates": "2.1.0",
+                "postcss-discard-empty": "2.1.0",
+                "postcss-discard-overridden": "0.1.1",
+                "postcss-discard-unused": "2.2.3",
+                "postcss-filter-plugins": "2.0.2",
+                "postcss-merge-idents": "2.1.7",
+                "postcss-merge-longhand": "2.0.2",
+                "postcss-merge-rules": "2.1.2",
+                "postcss-minify-font-values": "1.0.5",
+                "postcss-minify-gradients": "1.0.5",
+                "postcss-minify-params": "1.2.2",
+                "postcss-minify-selectors": "2.1.1",
+                "postcss-normalize-charset": "1.1.1",
+                "postcss-normalize-url": "3.0.8",
+                "postcss-ordered-values": "2.2.3",
+                "postcss-reduce-idents": "2.4.0",
+                "postcss-reduce-initial": "1.0.1",
+                "postcss-reduce-transforms": "1.0.4",
+                "postcss-svgo": "2.1.6",
+                "postcss-unique-selectors": "2.0.2",
+                "postcss-value-parser": "3.3.0",
+                "postcss-zindex": "2.2.0"
+            }
+        },
+        "csso": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+            "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+            "dev": true,
+            "requires": {
+                "clap": "1.2.3",
+                "source-map": "0.5.7"
+            }
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1500,6 +1741,12 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1563,6 +1810,12 @@
             "requires": {
                 "jsbn": "0.1.1"
             }
+        },
+        "electron-to-chromium": {
+            "version": "1.3.33",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+            "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+            "dev": true
         },
         "elliptic": {
             "version": "6.4.0",
@@ -1711,6 +1964,12 @@
                 "estraverse": "4.2.0"
             }
         },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+            "dev": true
+        },
         "esrecurse": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
@@ -1846,6 +2105,12 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
+        "fastparse": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+            "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+            "dev": true
+        },
         "fbjs": {
             "version": "0.8.16",
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
@@ -1910,6 +2175,12 @@
                 "locate-path": "2.0.0"
             }
         },
+        "flatten": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+            "dev": true
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1958,6 +2229,12 @@
                 "mkdirp": "0.5.1",
                 "rimraf": "2.6.2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2135,6 +2412,15 @@
                 "pinkie-promise": "2.0.1"
             }
         },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2220,6 +2506,12 @@
             "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
             "dev": true
         },
+        "html-comment-regex": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+            "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+            "dev": true
+        },
         "http-signature": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -2242,6 +2534,75 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
             "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
+        "icss-replace-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+            "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+            "dev": true
+        },
+        "icss-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+            "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+            "dev": true,
+            "requires": {
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
         "ieee754": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
@@ -2262,6 +2623,12 @@
             "requires": {
                 "repeating": "2.0.1"
             }
+        },
+        "indexes-of": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+            "dev": true
         },
         "indexof": {
             "version": "0.0.1",
@@ -2302,6 +2669,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-absolute-url": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+            "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
             "dev": true
         },
         "is-arrayish": {
@@ -2409,6 +2782,12 @@
                 "kind-of": "3.2.2"
             }
         },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2440,6 +2819,15 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-svg": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+            "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+            "dev": true,
+            "requires": {
+                "html-comment-regex": "1.1.1"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -2496,6 +2884,16 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "js-yaml": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+            "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
+            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -2650,10 +3048,22 @@
             "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
             "dev": true
         },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+            "dev": true
+        },
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
         },
         "lodash.mergewith": {
@@ -2666,6 +3076,12 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+            "dev": true
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
             "dev": true
         },
         "longest": {
@@ -2701,6 +3117,12 @@
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
             }
+        },
+        "macaddress": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+            "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+            "dev": true
         },
         "make-dir": {
             "version": "1.1.0",
@@ -3050,6 +3472,24 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+            "dev": true
+        },
+        "normalize-url": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "prepend-http": "1.0.4",
+                "query-string": "4.3.4",
+                "sort-keys": "1.1.2"
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3070,6 +3510,12 @@
                 "gauge": "2.7.4",
                 "set-blocking": "2.0.0"
             }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+            "dev": true
         },
         "number-is-nan": {
             "version": "1.0.1",
@@ -3323,6 +3769,580 @@
                 "find-up": "2.1.0"
             }
         },
+        "postcss": {
+            "version": "5.2.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "js-base64": "2.3.2",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-calc": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+            "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.3.0"
+            }
+        },
+        "postcss-colormin": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+            "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+            "dev": true,
+            "requires": {
+                "colormin": "1.1.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-convert-values": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+            "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-discard-comments": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+            "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-duplicates": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+            "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-empty": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+            "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-overridden": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+            "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-discard-unused": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+            "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-filter-plugins": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+            "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "uniqid": "4.1.1"
+            }
+        },
+        "postcss-merge-idents": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+            "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-merge-longhand": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+            "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-merge-rules": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+            "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+            "dev": true,
+            "requires": {
+                "browserslist": "1.7.7",
+                "caniuse-api": "1.6.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3",
+                "vendors": "1.0.1"
+            }
+        },
+        "postcss-message-helpers": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+            "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+            "dev": true
+        },
+        "postcss-minify-font-values": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+            "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-minify-gradients": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+            "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-minify-params": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+            "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-minify-selectors": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+            "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-selector-parser": "2.2.3"
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+            "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+            "dev": true,
+            "requires": {
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-local-by-default": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+            "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-scope": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+            "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "0.7.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-modules-values": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+            "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+            "dev": true,
+            "requires": {
+                "icss-replace-symbols": "1.1.0",
+                "postcss": "6.0.17"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "6.0.17",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+                    "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-normalize-charset": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+            "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-normalize-url": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+            "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+            "dev": true,
+            "requires": {
+                "is-absolute-url": "2.1.0",
+                "normalize-url": "1.9.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-ordered-values": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+            "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-reduce-idents": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+            "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-reduce-initial": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+            "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+            "dev": true,
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-reduce-transforms": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+            "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+            "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+            "dev": true,
+            "requires": {
+                "flatten": "1.0.2",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+            }
+        },
+        "postcss-svgo": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+            "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+            "dev": true,
+            "requires": {
+                "is-svg": "2.1.0",
+                "postcss": "5.2.18",
+                "postcss-value-parser": "3.3.0",
+                "svgo": "0.7.2"
+            }
+        },
+        "postcss-unique-selectors": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+            "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+            "dev": true
+        },
+        "postcss-zindex": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+            "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1",
+                "postcss": "5.2.18",
+                "uniqs": "2.0.0"
+            }
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3396,11 +4416,27 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
         "qs": {
             "version": "6.3.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
             "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
             "dev": true
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
+            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -3879,6 +4915,21 @@
                 "pify": "3.0.0"
             }
         },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "schema-utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+            "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.4.0"
+            }
+        },
         "scss-tokenizer": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -3992,6 +5043,15 @@
                 "hoek": "2.16.3"
             }
         },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "1.1.0"
+            }
+        },
         "source-list-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -4032,6 +5092,12 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "sshpk": {
@@ -4089,6 +5155,12 @@
                 "to-arraybuffer": "1.0.1",
                 "xtend": "4.0.1"
             }
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
         },
         "string-width": {
             "version": "1.0.2",
@@ -4149,11 +5221,36 @@
                 "get-stdin": "4.0.1"
             }
         },
+        "style-loader": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
+            "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.3.0"
+            }
+        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
+        },
+        "svgo": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+            "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+            "dev": true,
+            "requires": {
+                "coa": "1.0.4",
+                "colors": "1.1.2",
+                "csso": "2.3.2",
+                "js-yaml": "3.7.0",
+                "mkdirp": "0.5.1",
+                "sax": "1.2.4",
+                "whet.extend": "0.9.9"
+            }
         },
         "tapable": {
             "version": "0.2.8",
@@ -4322,6 +5419,27 @@
                 "webpack-sources": "1.0.2"
             }
         },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "uniqid": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+            "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+            "dev": true,
+            "requires": {
+                "macaddress": "0.2.8"
+            }
+        },
+        "uniqs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+            "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+            "dev": true
+        },
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4378,6 +5496,12 @@
                 "spdx-correct": "1.0.2",
                 "spdx-expression-parse": "1.0.4"
             }
+        },
+        "vendors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+            "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -4628,6 +5752,12 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
             "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        },
+        "whet.extend": {
+            "version": "0.9.9",
+            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+            "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+            "dev": true
         },
         "which": {
             "version": "1.3.0",

--- a/samples/widgets/UniversalWidget/package-lock.json
+++ b/samples/widgets/UniversalWidget/package-lock.json
@@ -1487,16 +1487,6 @@
                 "sha.js": "2.4.9"
             }
         },
-        "create-react-class": {
-            "version": "15.6.2",
-            "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-            "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
-            "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-            }
-        },
         "cross-spawn": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -1671,9 +1661,9 @@
             }
         },
         "d3": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.12.0.tgz",
-            "integrity": "sha512-ibAzFJrj1uuX+wIy29baTx9JebA5i670UKlp+H3c9pg0w8PKl8jpj4zf64MmLPVBXm2vA1i29obnWuM/rmyfWA==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
+            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
             "requires": {
                 "d3-array": "1.2.1",
                 "d3-axis": "1.0.8",
@@ -1686,8 +1676,8 @@
                 "d3-dsv": "1.0.8",
                 "d3-ease": "1.0.3",
                 "d3-force": "1.1.0",
-                "d3-format": "1.2.1",
-                "d3-geo": "1.9.0",
+                "d3-format": "1.2.2",
+                "d3-geo": "1.9.1",
                 "d3-hierarchy": "1.1.5",
                 "d3-interpolate": "1.1.6",
                 "d3-path": "1.0.5",
@@ -1697,7 +1687,7 @@
                 "d3-random": "1.1.0",
                 "d3-request": "1.0.6",
                 "d3-scale": "1.0.7",
-                "d3-selection": "1.2.0",
+                "d3-selection": "1.3.0",
                 "d3-shape": "1.2.0",
                 "d3-time": "1.0.8",
                 "d3-time-format": "2.1.1",
@@ -1705,6 +1695,13 @@
                 "d3-transition": "1.1.1",
                 "d3-voronoi": "1.1.2",
                 "d3-zoom": "1.7.1"
+            },
+            "dependencies": {
+                "d3-format": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+                    "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+                }
             }
         },
         "d3-array": {
@@ -1725,7 +1722,7 @@
                 "d3-dispatch": "1.0.3",
                 "d3-drag": "1.2.1",
                 "d3-interpolate": "1.1.6",
-                "d3-selection": "1.2.0",
+                "d3-selection": "1.3.0",
                 "d3-transition": "1.1.1"
             }
         },
@@ -1759,7 +1756,7 @@
             "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
             "requires": {
                 "d3-dispatch": "1.0.3",
-                "d3-selection": "1.2.0"
+                "d3-selection": "1.3.0"
             }
         },
         "d3-dsv": {
@@ -1794,9 +1791,9 @@
             "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w=="
         },
         "d3-geo": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.0.tgz",
-            "integrity": "sha512-94YbAT+q5E/p+XEd4VKiNkQNicrrON3l6eoW70sC8aHjUGoBDJ/Ht8Z/hvhGJJTi2zhYBvUd34Mfqv4TG7we9A==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
+            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
             "requires": {
                 "d3-array": "1.2.1"
             }
@@ -1808,7 +1805,7 @@
             "requires": {
                 "commander": "2.12.2",
                 "d3-array": "1.2.1",
-                "d3-geo": "1.9.0"
+                "d3-geo": "1.9.1"
             }
         },
         "d3-hierarchy": {
@@ -1875,9 +1872,9 @@
             }
         },
         "d3-selection": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.2.0.tgz",
-            "integrity": "sha512-xW2Pfcdzh1gOaoI+LGpPsLR2VpBQxuFoxvrvguK8ZmrJbPIVvfNG6pU6GNfK41D6Qz15sj61sbW/AFYuukwaLQ=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "d3-shape": {
             "version": "1.2.0",
@@ -1914,7 +1911,7 @@
                 "d3-dispatch": "1.0.3",
                 "d3-ease": "1.0.3",
                 "d3-interpolate": "1.1.6",
-                "d3-selection": "1.2.0",
+                "d3-selection": "1.3.0",
                 "d3-timer": "1.0.7"
             }
         },
@@ -1931,7 +1928,7 @@
                 "d3-dispatch": "1.0.3",
                 "d3-drag": "1.2.1",
                 "d3-interpolate": "1.1.6",
-                "d3-selection": "1.2.0",
+                "d3-selection": "1.3.0",
                 "d3-transition": "1.1.1"
             }
         },
@@ -2022,9 +2019,9 @@
             }
         },
         "dom-align": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.6.6.tgz",
-            "integrity": "sha512-yBCGmhzj6SRaeAJlFUK/iMDh6bBpQE7EuChyPnrV8LQFV3vo3XghZw2lgHgj/8o9USFunVlvJ6YXfQWVdGnV8Q=="
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.6.7.tgz",
+            "integrity": "sha512-FrHttKVCqdHaDyVjygY+8kRhcNOJEdvAkc2ltppJUz71ekgpzIOuLgsOIKVqzdETI2EocmW2DzF+uP365qcR5Q=="
         },
         "dom-helpers": {
             "version": "3.2.1",
@@ -4772,15 +4769,15 @@
             "integrity": "sha512-V1AN/gMNiJ3vOzbY/H3CTxhzYH+Ri2KlsEpo1SN8/SYmI4I/ZfQpScFAgmERuIGcLStA2sOEeBNVpH2FaOd2hA==",
             "requires": {
                 "babel-runtime": "6.26.0",
-                "dom-align": "1.6.6",
+                "dom-align": "1.6.7",
                 "prop-types": "15.6.0",
-                "rc-util": "4.3.1"
+                "rc-util": "4.4.0"
             }
         },
         "rc-animate": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.1.tgz",
-            "integrity": "sha512-hixobyAvDv0Oz4gHPOh67K4ck5Rz3JBBojBuKzYcu4b8JKMIiJxym83DfkkkYxXEEx/rwGf0mU0Dno/lbWghIQ==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.4.tgz",
+            "integrity": "sha512-DjJLTUQj7XKKcuS8cczN0uOLfuSmgrVXFGieP1SZc87xUUTFGh8B/KjNmEtlfvxkSrSuVfb2rrEPER4SqKUtEA==",
             "requires": {
                 "babel-runtime": "6.26.0",
                 "css-animation": "1.4.1",
@@ -4788,15 +4785,15 @@
             }
         },
         "rc-slider": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.5.0.tgz",
-            "integrity": "sha512-dw1kA7Dr6GOmPZFsy+yMxVyqmckeUtYVdfNOdQcI9O8mXkoCwlxXolMK9bW/TTlXCc8ztaXkJkyTVXl/Gkg5Tw==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.6.0.tgz",
+            "integrity": "sha512-Ek68lWlMZm2b9N0AevvBvd/1GRG+n/kvf2wpvSz4xkXawc2SXpF64auU2qF6eyvv98qhGFoDeyCELMATYddJkA==",
             "requires": {
                 "babel-runtime": "6.26.0",
                 "classnames": "2.2.5",
                 "prop-types": "15.6.0",
                 "rc-tooltip": "3.7.0",
-                "rc-util": "4.3.1",
+                "rc-util": "4.4.0",
                 "shallowequal": "1.0.2",
                 "warning": "3.0.0"
             }
@@ -4808,26 +4805,25 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "prop-types": "15.6.0",
-                "rc-trigger": "2.3.3"
+                "rc-trigger": "2.3.4"
             }
         },
         "rc-trigger": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.3.tgz",
-            "integrity": "sha512-j8MHq0jES4vXShFbSExyty/WVR238lrZzUfsSaIDeiziBIiUAOP6SR2HBEi2gSGK239Jm3bWIJvwGA85kFMgmQ==",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.4.tgz",
+            "integrity": "sha512-xPhda3SfGWHywEbVJu2VxpWg99ELStzNPcdnxb7lZ9XwUnHjUeX9KCaIbJa9GUuoVHx3mQP1s2m3ttIB8aashQ==",
             "requires": {
                 "babel-runtime": "6.26.0",
-                "create-react-class": "15.6.2",
                 "prop-types": "15.6.0",
                 "rc-align": "2.3.5",
-                "rc-animate": "2.4.1",
-                "rc-util": "4.3.1"
+                "rc-animate": "2.4.4",
+                "rc-util": "4.4.0"
             }
         },
         "rc-util": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.3.1.tgz",
-            "integrity": "sha512-OVNMKLePnwn0dCX/Gpc+/kGEDpmMo1Rfesg9xFcAckRd+D+YwVqV+dUJMHugP+4nRtbXi55o0HwPlkKIApYfQA==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.4.0.tgz",
+            "integrity": "sha512-PIWw9VBjLc2m4GZBPxMFT3QaOIMQ0PdzMjAs02nQ3RSPDt6oLzZ+rMBzN1AxcNkkpBbz0Zmdg3llZGzYraWFew==",
             "requires": {
                 "add-dom-event-listener": "1.0.2",
                 "babel-runtime": "6.26.0",
@@ -4917,9 +4913,9 @@
             }
         },
         "react-table": {
-            "version": "6.7.4",
-            "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.7.4.tgz",
-            "integrity": "sha512-V0D19Vriw0h4Ho0ECshMjgStOlsRUENYmYtgKtgv4DhpNcxQQ9lxhOdOHLda7uuiPZOJm6B3XvghfZsPTVaSNQ==",
+            "version": "6.7.6",
+            "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.7.6.tgz",
+            "integrity": "sha1-P547MIMozrBO+TpHur76uiYZyQU=",
             "requires": {
                 "classnames": "2.2.5"
             }
@@ -4948,21 +4944,22 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.7",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.7.tgz",
-            "integrity": "sha512-1Pc+tw1XY89X+mQQO1iggGOGtBAizekjEP4kSExnYS7iYwMR6LXIDnSEsQ/NGU78OjcODvwgx3tMTNvwoDGXMA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
             "requires": {
-                "d3": "4.12.0",
+                "d3": "4.13.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
-                "rc-slider": "8.5.0",
+                "rc-slider": "8.6.0",
                 "react": "16.2.0",
                 "react-dom": "16.2.0",
                 "react-simple-maps": "0.9.0",
-                "react-table": "6.7.4",
+                "react-table": "6.7.6",
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             }
         },
         "read-pkg": {
@@ -5994,9 +5991,9 @@
             }
         },
         "victory-core": {
-            "version": "20.3.0",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-            "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+            "version": "20.6.0",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+            "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
             "requires": {
                 "d3-ease": "1.0.3",
                 "d3-interpolate": "1.1.6",

--- a/samples/widgets/UniversalWidget/package.json
+++ b/samples/widgets/UniversalWidget/package.json
@@ -7,7 +7,7 @@
         "axios": "^0.17.1",
         "react": "^16.2.0",
         "react-dom": "^16.2.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.6.18",
         "rimraf": "^2.6.2"
     },
     "scripts": {

--- a/samples/widgets/UserInfo/package-lock.json
+++ b/samples/widgets/UserInfo/package-lock.json
@@ -1,13 +1,13 @@
 {
-    "name": "RevenueByRegion",
+    "name": "user-info-widget",
     "version": "0.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.0.0.tgz",
-            "integrity": "sha1-yaeAXvIm70xt0eHuToGc5QQ/2lI="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.1.1.tgz",
+            "integrity": "sha512-KcjZQERnpNLh7UPe14OGVEKFSwluUkpfc53cIK5mLVIA5janmTuu97MRCdbF+TjegS/E3lDD0MK4U3VY7rTMiQ=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -16,9 +16,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-            "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+            "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
             "dev": true
         },
         "acorn-dynamic-import": {
@@ -38,18 +38,10 @@
                 }
             }
         },
-        "add-dom-event-listener": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz",
-            "integrity": "sha1-j67SxBAIchzxEdodMNmVuFvkK+0=",
-            "requires": {
-                "object-assign": "4.1.1"
-            }
-        },
         "ajv": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
-            "integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
                 "co": "4.6.0",
@@ -74,12 +66,6 @@
                 "longest": "1.0.1",
                 "repeat-string": "1.6.1"
             }
-        },
-        "alphanum-sort": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-            "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
-            "dev": true
         },
         "amdefine": {
             "version": "1.0.1",
@@ -125,15 +111,6 @@
                 "readable-stream": "2.3.3"
             }
         },
-        "argparse": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "1.0.3"
-            }
-        },
         "arr-diff": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -155,10 +132,31 @@
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
         "array-unique": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
             "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
             "dev": true
         },
         "asap": {
@@ -224,20 +222,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
-        },
-        "autoprefixer": {
-            "version": "6.7.7",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-            "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-            "dev": true,
-            "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000777",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
         },
         "aws-sign2": {
             "version": "0.6.0",
@@ -825,7 +809,7 @@
             "requires": {
                 "babel-core": "6.26.0",
                 "babel-runtime": "6.26.0",
-                "core-js": "2.5.1",
+                "core-js": "2.5.3",
                 "home-or-tmp": "2.0.0",
                 "lodash": "4.17.4",
                 "mkdirp": "0.5.1",
@@ -833,9 +817,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-                    "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+                    "version": "2.5.3",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+                    "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
                     "dev": true
                 }
             }
@@ -844,15 +828,17 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
             "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.11.1"
             },
             "dependencies": {
                 "core-js": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-                    "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+                    "version": "2.5.3",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+                    "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+                    "dev": true
                 }
             }
         },
@@ -967,11 +953,6 @@
                 "hoek": "2.16.3"
             }
         },
-        "bowser": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.8.1.tgz",
-            "integrity": "sha512-NMPaR8ILtdLSWzxQtEs16XbxMcY8ohWGQ5V+TZSJS3fNUt/PBAGkF6YWO9B/4qWE23bK3o0moQKq8UyFEosYkA=="
-        },
         "brace-expansion": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1068,16 +1049,6 @@
                 "pako": "1.0.6"
             }
         },
-        "browserslist": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-            "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-            "dev": true,
-            "requires": {
-                "caniuse-db": "1.0.30000777",
-                "electron-to-chromium": "1.3.27"
-            }
-        },
         "buffer": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1107,6 +1078,27 @@
             "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
             "dev": true
         },
+        "cacache": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+            "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
+            "dev": true,
+            "requires": {
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.0.0",
+                "unique-filename": "1.1.0",
+                "y18n": "3.2.1"
+            }
+        },
         "camelcase": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -1122,24 +1114,6 @@
                 "camelcase": "2.1.1",
                 "map-obj": "1.0.1"
             }
-        },
-        "caniuse-api": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-            "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-            "dev": true,
-            "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000777",
-                "lodash.memoize": "4.1.2",
-                "lodash.uniq": "4.5.0"
-            }
-        },
-        "caniuse-db": {
-            "version": "1.0.30000777",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000777.tgz",
-            "integrity": "sha1-LhmtumO918UB32N6hirerX9LwFQ=",
-            "dev": true
         },
         "caseless": {
             "version": "0.11.0",
@@ -1168,7 +1142,8 @@
         "chain-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-            "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+            "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w=",
+            "dev": true
         },
         "chalk": {
             "version": "1.1.3",
@@ -1182,11 +1157,6 @@
                 "strip-ansi": "3.0.1",
                 "supports-color": "2.0.0"
             }
-        },
-        "change-emitter": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-            "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
         },
         "chokidar": {
             "version": "1.7.0",
@@ -1221,6 +1191,12 @@
                 }
             }
         },
+        "chownr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+            "dev": true
+        },
         "cipher-base": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -1231,19 +1207,11 @@
                 "safe-buffer": "5.1.1"
             }
         },
-        "clap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3"
-            }
-        },
         "classnames": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-            "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+            "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=",
+            "dev": true
         },
         "cliui": {
             "version": "3.2.0",
@@ -1255,12 +1223,6 @@
                 "strip-ansi": "3.0.1",
                 "wrap-ansi": "2.1.0"
             }
-        },
-        "clone": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
-            "dev": true
         },
         "clone-deep": {
             "version": "0.3.0",
@@ -1280,71 +1242,10 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
-        "coa": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-            "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-            "dev": true,
-            "requires": {
-                "q": "1.5.1"
-            }
-        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
-        },
-        "color": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-            "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-            "dev": true,
-            "requires": {
-                "clone": "1.0.3",
-                "color-convert": "1.9.1",
-                "color-string": "0.3.0"
-            }
-        },
-        "color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-            "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
-            }
-        },
-        "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "color-string": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-            "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-            "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
-            }
-        },
-        "colormin": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-            "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-            "dev": true,
-            "requires": {
-                "color": "0.11.4",
-                "css-color-names": "0.0.4",
-                "has": "1.0.1"
-            }
-        },
-        "colors": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
             "dev": true
         },
         "combined-stream": {
@@ -1357,9 +1258,10 @@
             }
         },
         "commander": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.1.tgz",
-            "integrity": "sha512-PCNLExLlI5HiPdaJs4pMXwOTHkSCpNQ1QJH9ykZLKtKEyKu3p9HgmH5l97vM8c0IUz6d54l+xEu2GG9yuYrFzA=="
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+            "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -1367,23 +1269,21 @@
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
         },
-        "component-classes": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
-            "integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=",
-            "requires": {
-                "component-indexof": "0.0.3"
-            }
-        },
-        "component-indexof": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
-            "integrity": "sha1-EdCRMSI5648yyPJa6csAL/6NPCQ="
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+            "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
+            }
         },
         "console-browserify": {
             "version": "1.1.0",
@@ -1412,18 +1312,36 @@
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
             "dev": true
         },
-        "copy-webpack-plugin": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.2.3.tgz",
-            "integrity": "sha512-cL/Wl3Y1QmmKThl/mWeGB+HH3YH+25tn8nhqEGsZda4Yn7GqGnDZ+TbeKJ7A6zvrxyNhhuviYAxn/tCyyAqh8Q==",
+        "copy-concurrently": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+            "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "glob": "7.1.2",
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
+            }
+        },
+        "copy-webpack-plugin": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.1.tgz",
+            "integrity": "sha512-xlcFiW/U7KrpS6dFuWq3r8Wb7koJx7QVc7LDFCosqkikaVSxkaYOnwDLwilbjrszZ0LYZXThDAJKcQCSrvdShQ==",
+            "dev": true,
+            "requires": {
+                "cacache": "10.0.1",
+                "find-cache-dir": "1.0.0",
+                "globby": "7.1.1",
                 "is-glob": "4.0.0",
                 "loader-utils": "0.2.17",
                 "lodash": "4.17.4",
-                "minimatch": "3.0.4"
+                "minimatch": "3.0.4",
+                "p-limit": "1.1.0",
+                "pify": "3.0.0",
+                "serialize-javascript": "1.4.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -1487,16 +1405,6 @@
                 "sha.js": "2.4.9"
             }
         },
-        "create-react-class": {
-            "version": "15.6.2",
-            "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-            "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
-            "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-            }
-        },
         "cross-spawn": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -1535,131 +1443,6 @@
                 "randomfill": "1.0.3"
             }
         },
-        "css-animation": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.4.1.tgz",
-            "integrity": "sha1-W4gTEl3g+7uwu+G0cq6EIhRpt6g=",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "component-classes": "1.2.6"
-            }
-        },
-        "css-color-names": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-            "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-            "dev": true
-        },
-        "css-in-js-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
-            "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
-            "requires": {
-                "hyphenate-style-name": "1.0.2"
-            }
-        },
-        "css-loader": {
-            "version": "0.28.7",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
-            "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "6.26.0",
-                "css-selector-tokenizer": "0.7.0",
-                "cssnano": "3.10.0",
-                "icss-utils": "2.1.0",
-                "loader-utils": "1.1.0",
-                "lodash.camelcase": "4.3.0",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-modules-extract-imports": "1.1.0",
-                "postcss-modules-local-by-default": "1.2.0",
-                "postcss-modules-scope": "1.1.0",
-                "postcss-modules-values": "1.3.0",
-                "postcss-value-parser": "3.3.0",
-                "source-list-map": "2.0.0"
-            }
-        },
-        "css-selector-tokenizer": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-            "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-            "dev": true,
-            "requires": {
-                "cssesc": "0.1.0",
-                "fastparse": "1.1.1",
-                "regexpu-core": "1.0.0"
-            },
-            "dependencies": {
-                "regexpu-core": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-                    "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-                    "dev": true,
-                    "requires": {
-                        "regenerate": "1.3.3",
-                        "regjsgen": "0.2.0",
-                        "regjsparser": "0.1.5"
-                    }
-                }
-            }
-        },
-        "cssesc": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
-            "dev": true
-        },
-        "cssnano": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-            "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-            "dev": true,
-            "requires": {
-                "autoprefixer": "6.7.7",
-                "decamelize": "1.2.0",
-                "defined": "1.0.0",
-                "has": "1.0.1",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-calc": "5.3.1",
-                "postcss-colormin": "2.2.2",
-                "postcss-convert-values": "2.6.1",
-                "postcss-discard-comments": "2.0.4",
-                "postcss-discard-duplicates": "2.1.0",
-                "postcss-discard-empty": "2.1.0",
-                "postcss-discard-overridden": "0.1.1",
-                "postcss-discard-unused": "2.2.3",
-                "postcss-filter-plugins": "2.0.2",
-                "postcss-merge-idents": "2.1.7",
-                "postcss-merge-longhand": "2.0.2",
-                "postcss-merge-rules": "2.1.2",
-                "postcss-minify-font-values": "1.0.5",
-                "postcss-minify-gradients": "1.0.5",
-                "postcss-minify-params": "1.2.2",
-                "postcss-minify-selectors": "2.1.1",
-                "postcss-normalize-charset": "1.1.1",
-                "postcss-normalize-url": "3.0.8",
-                "postcss-ordered-values": "2.2.3",
-                "postcss-reduce-idents": "2.4.0",
-                "postcss-reduce-initial": "1.0.1",
-                "postcss-reduce-transforms": "1.0.4",
-                "postcss-svgo": "2.1.6",
-                "postcss-unique-selectors": "2.0.2",
-                "postcss-value-parser": "3.3.0",
-                "postcss-zindex": "2.2.0"
-            }
-        },
-        "csso": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-            "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-            "dev": true,
-            "requires": {
-                "clap": "1.2.3",
-                "source-map": "0.5.7"
-            }
-        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1668,6 +1451,12 @@
             "requires": {
                 "array-find-index": "1.0.2"
             }
+        },
+        "cyclist": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+            "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+            "dev": true
         },
         "d": {
             "version": "1.0.0",
@@ -1678,172 +1467,35 @@
                 "es5-ext": "0.10.37"
             }
         },
-        "d3": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.12.0.tgz",
-            "integrity": "sha512-ibAzFJrj1uuX+wIy29baTx9JebA5i670UKlp+H3c9pg0w8PKl8jpj4zf64MmLPVBXm2vA1i29obnWuM/rmyfWA==",
-            "requires": {
-                "d3-array": "1.2.1",
-                "d3-axis": "1.0.8",
-                "d3-brush": "1.0.4",
-                "d3-chord": "1.0.4",
-                "d3-collection": "1.0.4",
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-dsv": "1.0.8",
-                "d3-ease": "1.0.3",
-                "d3-force": "1.1.0",
-                "d3-format": "1.2.1",
-                "d3-geo": "1.9.0",
-                "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.6",
-                "d3-path": "1.0.5",
-                "d3-polygon": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-queue": "3.0.7",
-                "d3-random": "1.1.0",
-                "d3-request": "1.0.6",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.2.0",
-                "d3-shape": "1.2.0",
-                "d3-time": "1.0.8",
-                "d3-time-format": "2.1.1",
-                "d3-timer": "1.0.7",
-                "d3-transition": "1.1.1",
-                "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.7.1"
-            },
-            "dependencies": {
-                "d3-scale": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-                    "requires": {
-                        "d3-array": "1.2.1",
-                        "d3-collection": "1.0.4",
-                        "d3-color": "1.0.3",
-                        "d3-format": "1.2.1",
-                        "d3-interpolate": "1.1.6",
-                        "d3-time": "1.0.8",
-                        "d3-time-format": "2.1.1"
-                    }
-                }
-            }
-        },
         "d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
-            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
-        },
-        "d3-axis": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo="
-        },
-        "d3-brush": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
-            "integrity": "sha1-AMLyOAGfJPbAoZSibUGhUw/+e8Q=",
-            "requires": {
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-interpolate": "1.1.6",
-                "d3-selection": "1.2.0",
-                "d3-transition": "1.1.1"
-            }
-        },
-        "d3-chord": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
-            "integrity": "sha1-fexPC6iG9xP+ERxF92NBT290yiw=",
-            "requires": {
-                "d3-array": "1.2.1",
-                "d3-path": "1.0.5"
-            }
+            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw==",
+            "dev": true
         },
         "d3-collection": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
-            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
+            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI=",
+            "dev": true
         },
         "d3-color": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
-        },
-        "d3-dispatch": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
-            "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg="
-        },
-        "d3-drag": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
-            "requires": {
-                "d3-dispatch": "1.0.3",
-                "d3-selection": "1.2.0"
-            }
-        },
-        "d3-dsv": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
-            "requires": {
-                "commander": "2.12.1",
-                "iconv-lite": "0.4.19",
-                "rw": "1.3.3"
-            }
-        },
-        "d3-ease": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
-        },
-        "d3-force": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
-            "requires": {
-                "d3-collection": "1.0.4",
-                "d3-dispatch": "1.0.3",
-                "d3-quadtree": "1.0.3",
-                "d3-timer": "1.0.7"
-            }
+            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs=",
+            "dev": true
         },
         "d3-format": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.1.tgz",
-            "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w=="
-        },
-        "d3-geo": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.0.tgz",
-            "integrity": "sha512-94YbAT+q5E/p+XEd4VKiNkQNicrrON3l6eoW70sC8aHjUGoBDJ/Ht8Z/hvhGJJTi2zhYBvUd34Mfqv4TG7we9A==",
-            "requires": {
-                "d3-array": "1.2.1"
-            }
-        },
-        "d3-geo-projection": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-1.2.2.tgz",
-            "integrity": "sha1-7w5s3PoN8jbQ4j8sp3UEYsozH3I=",
-            "requires": {
-                "commander": "2.12.1",
-                "d3-array": "1.2.1",
-                "d3-geo": "1.9.0"
-            }
-        },
-        "d3-hierarchy": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY="
+            "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w==",
+            "dev": true
         },
         "d3-interpolate": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
             "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "dev": true,
             "requires": {
                 "d3-color": "1.0.3"
             }
@@ -1851,43 +1503,14 @@
         "d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
-        },
-        "d3-polygon": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI="
-        },
-        "d3-quadtree": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-            "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
-        },
-        "d3-queue": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha1-yTouVLQXwJWRKdfXP2z31Ckudhg="
-        },
-        "d3-random": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM="
-        },
-        "d3-request": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-            "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "requires": {
-                "d3-collection": "1.0.4",
-                "d3-dispatch": "1.0.3",
-                "d3-dsv": "1.0.8",
-                "xmlhttprequest": "1.8.0"
-            }
+            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q=",
+            "dev": true
         },
         "d3-scale": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.6.tgz",
             "integrity": "sha1-vOGdqA06DPQiyVQ64zIghiILNO0=",
+            "dev": true,
             "requires": {
                 "d3-array": "1.2.1",
                 "d3-collection": "1.0.4",
@@ -1898,15 +1521,11 @@
                 "d3-time-format": "2.1.1"
             }
         },
-        "d3-selection": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.2.0.tgz",
-            "integrity": "sha512-xW2Pfcdzh1gOaoI+LGpPsLR2VpBQxuFoxvrvguK8ZmrJbPIVvfNG6pU6GNfK41D6Qz15sj61sbW/AFYuukwaLQ=="
-        },
         "d3-shape": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
             "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
+            "dev": true,
             "requires": {
                 "d3-path": "1.0.5"
             }
@@ -1914,49 +1533,16 @@
         "d3-time": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ==",
+            "dev": true
         },
         "d3-time-format": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
             "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "dev": true,
             "requires": {
                 "d3-time": "1.0.8"
-            }
-        },
-        "d3-timer": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
-        },
-        "d3-transition": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
-            "requires": {
-                "d3-color": "1.0.3",
-                "d3-dispatch": "1.0.3",
-                "d3-ease": "1.0.3",
-                "d3-interpolate": "1.1.6",
-                "d3-selection": "1.2.0",
-                "d3-timer": "1.0.7"
-            }
-        },
-        "d3-voronoi": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
-        },
-        "d3-zoom": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
-            "requires": {
-                "d3-dispatch": "1.0.3",
-                "d3-drag": "1.2.1",
-                "d3-interpolate": "1.1.6",
-                "d3-selection": "1.2.0",
-                "d3-transition": "1.1.1"
             }
         },
         "dashdash": {
@@ -1995,12 +1581,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
-        },
-        "defined": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
             "dev": true
         },
         "delayed-stream": {
@@ -2045,21 +1625,39 @@
                 "randombytes": "2.0.5"
             }
         },
-        "dom-align": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.6.5.tgz",
-            "integrity": "sha512-f/JRwEZOv8Dfsv4yIy4s7LRNwmiD80PlnYSa9fJfLaYinUSjrChdNvDvXRZDX/+CKBZWCsPN1Co0aM38xy4RpA=="
+        "dir-glob": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+            "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+            "dev": true,
+            "requires": {
+                "arrify": "1.0.1",
+                "path-type": "3.0.0"
+            }
         },
         "dom-helpers": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
-            "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+            "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==",
+            "dev": true
         },
         "domain-browser": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
             "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
             "dev": true
+        },
+        "duplexify": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+            "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+            }
         },
         "ecc-jsbn": {
             "version": "0.1.1",
@@ -2070,12 +1668,6 @@
             "requires": {
                 "jsbn": "0.1.1"
             }
-        },
-        "electron-to-chromium": {
-            "version": "1.3.27",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-            "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
-            "dev": true
         },
         "elliptic": {
             "version": "6.4.0",
@@ -2106,6 +1698,15 @@
                 "iconv-lite": "0.4.19"
             }
         },
+        "end-of-stream": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+            "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
         "enhanced-resolve": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
@@ -2119,12 +1720,12 @@
             }
         },
         "errno": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-            "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+            "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
             "dev": true,
             "requires": {
-                "prr": "0.0.0"
+                "prr": "1.0.1"
             }
         },
         "error-ex": {
@@ -2223,12 +1824,6 @@
                 "esrecurse": "4.2.0",
                 "estraverse": "4.2.0"
             }
-        },
-        "esprima": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-            "dev": true
         },
         "esrecurse": {
             "version": "4.2.0",
@@ -2365,12 +1960,6 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
-        "fastparse": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-            "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
-            "dev": true
-        },
         "fbjs": {
             "version": "0.8.16",
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
@@ -2435,11 +2024,15 @@
                 "locate-path": "2.0.0"
             }
         },
-        "flatten": {
+        "flush-write-stream": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+            "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
         },
         "for-in": {
             "version": "1.0.2",
@@ -2473,6 +2066,28 @@
                 "mime-types": "2.1.17"
             }
         },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "fs-write-stream-atomic": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+            "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2489,12 +2104,6 @@
                 "mkdirp": "0.5.1",
                 "rimraf": "2.6.2"
             }
-        },
-        "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2643,6 +2252,20 @@
             "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
             "dev": true
         },
+        "globby": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+            "dev": true,
+            "requires": {
+                "array-union": "1.0.2",
+                "dir-glob": "2.0.0",
+                "glob": "7.1.2",
+                "ignore": "3.3.7",
+                "pify": "3.0.0",
+                "slash": "1.0.0"
+            }
+        },
         "globule": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
@@ -2667,18 +2290,9 @@
             "dev": true,
             "requires": {
                 "chalk": "1.1.3",
-                "commander": "2.12.1",
-                "is-my-json-valid": "2.16.1",
+                "commander": "2.12.2",
+                "is-my-json-valid": "2.17.1",
                 "pinkie-promise": "2.0.1"
-            }
-        },
-        "has": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-            "dev": true,
-            "requires": {
-                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -2750,11 +2364,6 @@
             "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
             "dev": true
         },
-        "hoist-non-react-statics": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-            "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-        },
         "home-or-tmp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -2769,12 +2378,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
             "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-            "dev": true
-        },
-        "html-comment-regex": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
-            "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
             "dev": true
         },
         "http-signature": {
@@ -2794,83 +2397,33 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
-        "hyphenate-style-name": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-            "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
-        },
         "iconv-lite": {
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
             "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
-        "icss-replace-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-            "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-            "dev": true
-        },
-        "icss-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
-            "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
-            "dev": true,
-            "requires": {
-                "postcss": "6.0.14"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
-            }
-        },
         "ieee754": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
             "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+            "dev": true
+        },
+        "iferr": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+            "dev": true
+        },
+        "ignore": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+            "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
         "in-publish": {
@@ -2887,12 +2440,6 @@
             "requires": {
                 "repeating": "2.0.1"
             }
-        },
-        "indexes-of": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-            "dev": true
         },
         "indexof": {
             "version": "0.0.1",
@@ -2914,19 +2461,10 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
-        "inline-style-prefixer": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-            "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-            "requires": {
-                "bowser": "1.8.1",
-                "css-in-js-utils": "2.0.0"
-            }
-        },
         "interpret": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-            "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
             "dev": true
         },
         "invariant": {
@@ -2942,12 +2480,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
-        },
-        "is-absolute-url": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
-            "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
             "dev": true
         },
         "is-arrayish": {
@@ -3035,9 +2567,9 @@
             }
         },
         "is-my-json-valid": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-            "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+            "version": "2.17.1",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+            "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
             "dev": true,
             "requires": {
                 "generate-function": "2.0.0",
@@ -3054,12 +2586,6 @@
             "requires": {
                 "kind-of": "3.2.2"
             }
-        },
-        "is-plain-obj": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -3092,15 +2618,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "is-svg": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-            "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-            "dev": true,
-            "requires": {
-                "html-comment-regex": "1.1.1"
-            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -3148,25 +2665,15 @@
             "dev": true
         },
         "js-base64": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-            "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+            "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
             "dev": true
         },
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "js-yaml": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-            "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-            "dev": true,
-            "requires": {
-                "argparse": "1.0.9",
-                "esprima": "2.7.3"
-            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -3236,11 +2743,6 @@
                     "dev": true
                 }
             }
-        },
-        "keycode": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
-            "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
         },
         "kind-of": {
             "version": "3.2.2",
@@ -3317,12 +2819,8 @@
         "lodash": {
             "version": "4.17.4",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
         },
         "lodash.assign": {
             "version": "4.2.0",
@@ -3330,48 +2828,11 @@
             "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
             "dev": true
         },
-        "lodash.camelcase": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-            "dev": true
-        },
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
-            }
-        },
-        "lodash.memoize": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-            "dev": true
-        },
-        "lodash.merge": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-            "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
         },
         "lodash.mergewith": {
             "version": "4.6.0",
@@ -3383,17 +2844,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
-            "dev": true
-        },
-        "lodash.throttle": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-        },
-        "lodash.uniq": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
             "dev": true
         },
         "longest": {
@@ -3430,12 +2880,6 @@
                 "yallist": "2.1.2"
             }
         },
-        "macaddress": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-            "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-            "dev": true
-        },
         "make-dir": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
@@ -3450,38 +2894,6 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
-        },
-        "material-ui": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.19.4.tgz",
-            "integrity": "sha1-ypzcqKqLtZTfrF2zjsn/BFoyNYc=",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "inline-style-prefixer": "3.0.8",
-                "keycode": "2.1.9",
-                "lodash.merge": "4.6.0",
-                "lodash.throttle": "4.1.1",
-                "prop-types": "15.6.0",
-                "react-event-listener": "0.5.1",
-                "react-transition-group": "1.2.1",
-                "recompose": "0.26.0",
-                "simple-assign": "0.1.0",
-                "warning": "3.0.0"
-            },
-            "dependencies": {
-                "react-transition-group": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-                    "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
-                    "requires": {
-                        "chain-function": "1.0.0",
-                        "dom-helpers": "3.2.1",
-                        "loose-envify": "1.3.1",
-                        "prop-types": "15.6.0",
-                        "warning": "3.0.0"
-                    }
-                }
-            }
         },
         "math-expression-evaluator": {
             "version": "1.2.17",
@@ -3526,7 +2938,7 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "0.1.4",
+                "errno": "0.1.6",
                 "readable-stream": "2.3.3"
             }
         },
@@ -3651,6 +3063,24 @@
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
+        "mississippi": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+            "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "1.6.0",
+                "duplexify": "3.5.1",
+                "end-of-stream": "1.4.0",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "1.0.3",
+                "pumpify": "1.3.5",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
+            }
+        },
         "mixin-object": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
@@ -3676,6 +3106,20 @@
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
+            }
+        },
+        "move-concurrently": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+            "dev": true,
+            "requires": {
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "ms": {
@@ -3816,24 +3260,6 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
-        "normalize-range": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-            "dev": true
-        },
-        "normalize-url": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-            "dev": true,
-            "requires": {
-                "object-assign": "4.1.1",
-                "prepend-http": "1.0.4",
-                "query-string": "4.3.4",
-                "sort-keys": "1.1.2"
-            }
-        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3854,12 +3280,6 @@
                 "gauge": "2.7.4",
                 "set-blocking": "2.0.0"
             }
-        },
-        "num2fraction": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-            "dev": true
         },
         "number-is-nan": {
             "version": "1.0.1",
@@ -3971,6 +3391,17 @@
             "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
             "dev": true
         },
+        "parallel-transform": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+            "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+            "dev": true,
+            "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "parse-asn1": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
@@ -4046,22 +3477,12 @@
             "dev": true
         },
         "path-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
+                "pify": "3.0.0"
             }
         },
         "pbkdf2": {
@@ -4113,556 +3534,6 @@
                 "find-up": "2.1.0"
             }
         },
-        "postcss": {
-            "version": "5.2.18",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.3.2",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-calc": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-            "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18",
-                "postcss-message-helpers": "2.0.0",
-                "reduce-css-calc": "1.3.0"
-            }
-        },
-        "postcss-colormin": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-            "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-            "dev": true,
-            "requires": {
-                "colormin": "1.1.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-convert-values": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
-            "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-discard-comments": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-            "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18"
-            }
-        },
-        "postcss-discard-duplicates": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
-            "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18"
-            }
-        },
-        "postcss-discard-empty": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-            "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18"
-            }
-        },
-        "postcss-discard-overridden": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-            "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18"
-            }
-        },
-        "postcss-discard-unused": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-            "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
-            }
-        },
-        "postcss-filter-plugins": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-            "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18",
-                "uniqid": "4.1.1"
-            }
-        },
-        "postcss-merge-idents": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-            "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-            "dev": true,
-            "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-merge-longhand": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
-            "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18"
-            }
-        },
-        "postcss-merge-rules": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-            "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-            "dev": true,
-            "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-api": "1.6.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.1"
-            }
-        },
-        "postcss-message-helpers": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-            "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
-            "dev": true
-        },
-        "postcss-minify-font-values": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-            "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-            "dev": true,
-            "requires": {
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-minify-gradients": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-            "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-minify-params": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-            "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-            "dev": true,
-            "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "uniqs": "2.0.0"
-            }
-        },
-        "postcss-minify-selectors": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-            "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-            "dev": true,
-            "requires": {
-                "alphanum-sort": "1.0.2",
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3"
-            }
-        },
-        "postcss-modules-extract-imports": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
-            "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
-            "dev": true,
-            "requires": {
-                "postcss": "6.0.14"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-modules-local-by-default": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-            "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
-            "dev": true,
-            "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.14"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-modules-scope": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-            "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
-            "dev": true,
-            "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.14"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-modules-values": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-            "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
-            "dev": true,
-            "requires": {
-                "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.14"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-                    "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-normalize-charset": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-            "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18"
-            }
-        },
-        "postcss-normalize-url": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-            "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-            "dev": true,
-            "requires": {
-                "is-absolute-url": "2.1.0",
-                "normalize-url": "1.9.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-ordered-values": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
-            "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-reduce-idents": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
-            "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-reduce-initial": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
-            "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-            "dev": true,
-            "requires": {
-                "postcss": "5.2.18"
-            }
-        },
-        "postcss-reduce-transforms": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-            "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-            "dev": true,
-            "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
-            }
-        },
-        "postcss-selector-parser": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-            "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-            "dev": true,
-            "requires": {
-                "flatten": "1.0.2",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
-            }
-        },
-        "postcss-svgo": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-            "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-            "dev": true,
-            "requires": {
-                "is-svg": "2.1.0",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "svgo": "0.7.2"
-            }
-        },
-        "postcss-unique-selectors": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-            "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-            "dev": true,
-            "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
-            }
-        },
-        "postcss-value-parser": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
-            "dev": true
-        },
-        "postcss-zindex": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-            "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-            "dev": true,
-            "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
-            }
-        },
-        "prepend-http": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-            "dev": true
-        },
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -4695,6 +3566,12 @@
                 "asap": "2.0.6"
             }
         },
+        "promise-inflight": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+            "dev": true
+        },
         "prop-types": {
             "version": "15.6.0",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
@@ -4706,9 +3583,9 @@
             }
         },
         "prr": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-            "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
             "dev": true
         },
         "pseudomap": {
@@ -4730,16 +3607,31 @@
                 "randombytes": "2.0.5"
             }
         },
+        "pump": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+            "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.0",
+                "once": "1.4.0"
+            }
+        },
+        "pumpify": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+            "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.1",
+                "inherits": "2.0.3",
+                "pump": "1.0.3"
+            }
+        },
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-            "dev": true
-        },
-        "q": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
             "dev": true
         },
         "qs": {
@@ -4747,16 +3639,6 @@
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
             "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
             "dev": true
-        },
-        "query-string": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-            "dev": true,
-            "requires": {
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
-            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -4839,89 +3721,10 @@
                 "safe-buffer": "5.1.1"
             }
         },
-        "rc-align": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.3.5.tgz",
-            "integrity": "sha512-V1AN/gMNiJ3vOzbY/H3CTxhzYH+Ri2KlsEpo1SN8/SYmI4I/ZfQpScFAgmERuIGcLStA2sOEeBNVpH2FaOd2hA==",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "dom-align": "1.6.5",
-                "prop-types": "15.6.0",
-                "rc-util": "4.3.0"
-            }
-        },
-        "rc-animate": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.1.tgz",
-            "integrity": "sha512-hixobyAvDv0Oz4gHPOh67K4ck5Rz3JBBojBuKzYcu4b8JKMIiJxym83DfkkkYxXEEx/rwGf0mU0Dno/lbWghIQ==",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "css-animation": "1.4.1",
-                "prop-types": "15.6.0"
-            }
-        },
-        "rc-slider": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.5.0.tgz",
-            "integrity": "sha512-dw1kA7Dr6GOmPZFsy+yMxVyqmckeUtYVdfNOdQcI9O8mXkoCwlxXolMK9bW/TTlXCc8ztaXkJkyTVXl/Gkg5Tw==",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "classnames": "2.2.5",
-                "prop-types": "15.6.0",
-                "rc-tooltip": "3.7.0",
-                "rc-util": "4.3.0",
-                "shallowequal": "1.0.2",
-                "warning": "3.0.0"
-            }
-        },
-        "rc-tooltip": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.0.tgz",
-            "integrity": "sha512-xEoUMatXp8OEL61UFH0+NrC39nkKzpOBhLrJCnnRpDRduU8L3DOhF6CNlIMkvg68hxlGGdquFtFw2t+1xNLX5A==",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.0",
-                "rc-trigger": "2.3.1"
-            }
-        },
-        "rc-trigger": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.1.tgz",
-            "integrity": "sha512-QvRU8d9V6HsKz/ot96i0WoQtBqzq+hFPZsS3pM1zgNah/81XZkqqGSC+ibAFrcz17RIAEGU/SmzvYPx6LhQ/1Q==",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "create-react-class": "15.6.2",
-                "prop-types": "15.6.0",
-                "rc-align": "2.3.5",
-                "rc-animate": "2.4.1",
-                "rc-util": "4.3.0"
-            }
-        },
-        "rc-util": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.3.0.tgz",
-            "integrity": "sha512-PUY5w0oFnk1dBKJKhWVy6k1HOxk35d8xmWMeyWuhEG0Sfy/OuvP3aoaYy7Xx5bt55ecV5imjD6MlmAt2aC+ynQ==",
-            "requires": {
-                "add-dom-event-listener": "1.0.2",
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.0",
-                "shallowequal": "0.2.2"
-            },
-            "dependencies": {
-                "shallowequal": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
-                    "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
-                    "requires": {
-                        "lodash.keys": "3.1.2"
-                    }
-                }
-            }
-        },
         "react": {
-            "version": "16.1.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.1.1.tgz",
-            "integrity": "sha512-FQfiFfk2z2Fk87OngNJHT05KyC9DOVn8LPeB7ZX+9u5+yU1JK6o5ozRlU3PeOMr0IFkWNvgn9jU8/IhRxR1F0g==",
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+            "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
             "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -4930,25 +3733,14 @@
             }
         },
         "react-dom": {
-            "version": "16.1.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.1.1.tgz",
-            "integrity": "sha512-q06jiwST8SEPAMIEkAsu7BgynEZtqF87VrTc70XsW7nxVhWEu2Y4MF5UfxxHQO/mNtQHQWP0YcFxmwm9oMrMaQ==",
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+            "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
             "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
                 "object-assign": "4.1.1",
                 "prop-types": "15.6.0"
-            }
-        },
-        "react-event-listener": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.1.tgz",
-            "integrity": "sha1-ujYHbke8N8Wmf/XM1Kn/DxViEEA=",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "fbjs": "0.8.16",
-                "prop-types": "15.6.0",
-                "warning": "3.0.0"
             }
         },
         "react-resize-detector": {
@@ -4958,34 +3750,6 @@
             "dev": true,
             "requires": {
                 "prop-types": "15.6.0"
-            }
-        },
-        "react-simple-maps": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-0.9.0.tgz",
-            "integrity": "sha512-6nH0VUB1z+kwsgChZo3E+jc2uWp9MdTqut+SSTiEFXlWfeRgG4Nc0/YkSOIZUwbGCoEpPsdpQDaoaMspQcC+uw==",
-            "requires": {
-                "d3-geo": "1.6.3",
-                "d3-geo-projection": "1.2.2",
-                "topojson-client": "2.1.0"
-            },
-            "dependencies": {
-                "d3-geo": {
-                    "version": "1.6.3",
-                    "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.6.3.tgz",
-                    "integrity": "sha1-IWg6Q6Bh6rohp/JUtR1ZN+tkB1Y=",
-                    "requires": {
-                        "d3-array": "1.2.1"
-                    }
-                },
-                "topojson-client": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
-                    "integrity": "sha1-/59784mRGF4LQoTCsGroNPDqxsg=",
-                    "requires": {
-                        "commander": "2.12.1"
-                    }
-                }
             }
         },
         "react-smooth": {
@@ -5000,23 +3764,6 @@
                 "react-transition-group": "2.2.1"
             }
         },
-        "react-table": {
-            "version": "6.7.4",
-            "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.7.4.tgz",
-            "integrity": "sha512-V0D19Vriw0h4Ho0ECshMjgStOlsRUENYmYtgKtgv4DhpNcxQQ9lxhOdOHLda7uuiPZOJm6B3XvghfZsPTVaSNQ==",
-            "requires": {
-                "classnames": "2.2.5"
-            }
-        },
-        "react-tooltip": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.4.0.tgz",
-            "integrity": "sha1-A38495fD5rG1jSU0zMjCx2r09S0=",
-            "requires": {
-                "classnames": "2.2.5",
-                "prop-types": "15.6.0"
-            }
-        },
         "react-transition-group": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
@@ -5025,43 +3772,10 @@
             "requires": {
                 "chain-function": "1.0.0",
                 "classnames": "2.2.5",
-                "dom-helpers": "3.2.1",
+                "dom-helpers": "3.3.1",
                 "loose-envify": "1.3.1",
                 "prop-types": "15.6.0",
                 "warning": "3.0.0"
-            }
-        },
-        "react-vizgrammar": {
-            "version": "0.6.17",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.17.tgz",
-            "integrity": "sha512-u3nnP1nC02kz1/U+AWtj1gZOh9eMk1arfm3/AJfJNzJUOCw0tMM6UljlduB28SWL3pNXshoyfC7ZyRbXLb7u+Q==",
-            "requires": {
-                "d3": "4.12.0",
-                "prop-types": "15.6.0",
-                "rc-slider": "8.5.0",
-                "react": "16.1.1",
-                "react-dom": "16.1.1",
-                "react-simple-maps": "0.9.0",
-                "react-table": "6.7.4",
-                "react-tooltip": "3.4.0",
-                "topojson-client": "3.0.0",
-                "victory": "0.22.2",
-                "victory-core": "20.6.0"
-            },
-            "dependencies": {
-                "victory-core": {
-                    "version": "20.6.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
-                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
-                    "requires": {
-                        "d3-ease": "1.0.3",
-                        "d3-interpolate": "1.1.6",
-                        "d3-scale": "1.0.6",
-                        "d3-shape": "1.2.0",
-                        "d3-timer": "1.0.7",
-                        "lodash": "4.17.4"
-                    }
-                }
             }
         },
         "read-pkg": {
@@ -5073,6 +3787,25 @@
                 "load-json-file": "1.1.0",
                 "normalize-package-data": "2.4.0",
                 "path-type": "1.1.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
             }
         },
         "read-pkg-up": {
@@ -5134,9 +3867,9 @@
             }
         },
         "recharts": {
-            "version": "1.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.0.0-beta.4.tgz",
-            "integrity": "sha1-k7rnKrU5cZD/b/LrhQikyJCkZ5Y=",
+            "version": "1.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.0.0-beta.7.tgz",
+            "integrity": "sha1-/M+T6vWVH3Q4y3a1pd0P50rVRFA=",
             "dev": true,
             "requires": {
                 "classnames": "2.2.5",
@@ -5165,17 +3898,6 @@
             "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.3.2.tgz",
             "integrity": "sha1-2sdiFxSkdl0VLLKtvDDHO4MSCMk=",
             "dev": true
-        },
-        "recompose": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-            "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-            "requires": {
-                "change-emitter": "0.1.6",
-                "fbjs": "0.8.16",
-                "hoist-non-react-statics": "2.3.1",
-                "symbol-observable": "1.1.0"
-            }
         },
         "redent": {
             "version": "1.0.0",
@@ -5230,9 +3952,10 @@
             "dev": true
         },
         "regenerator-runtime": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-            "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "dev": true
         },
         "regenerator-transform": {
             "version": "0.10.1",
@@ -5382,10 +4105,14 @@
                 "inherits": "2.0.3"
             }
         },
-        "rw": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-            "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+        "run-queue": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+            "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+            "dev": true,
+            "requires": {
+                "aproba": "1.2.0"
+            }
         },
         "safe-buffer": {
             "version": "5.1.1",
@@ -5418,28 +4145,13 @@
                 "pify": "3.0.0"
             }
         },
-        "sax": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-            "dev": true
-        },
-        "schema-utils": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-            "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-            "dev": true,
-            "requires": {
-                "ajv": "5.4.0"
-            }
-        },
         "scss-tokenizer": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "dev": true,
             "requires": {
-                "js-base64": "2.3.2",
+                "js-base64": "2.4.0",
                 "source-map": "0.4.4"
             },
             "dependencies": {
@@ -5458,6 +4170,12 @@
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
             "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+            "dev": true
+        },
+        "serialize-javascript": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+            "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
             "dev": true
         },
         "set-blocking": {
@@ -5510,11 +4228,6 @@
                 }
             }
         },
-        "shallowequal": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-            "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
-        },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -5536,11 +4249,6 @@
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
-        "simple-assign": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
-            "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
-        },
         "slash": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -5554,15 +4262,6 @@
             "dev": true,
             "requires": {
                 "hoek": "2.16.3"
-            }
-        },
-        "sort-keys": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-            "dev": true,
-            "requires": {
-                "is-plain-obj": "1.1.0"
             }
         },
         "source-list-map": {
@@ -5607,12 +4306,6 @@
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
             "dev": true
         },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
         "sshpk": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
@@ -5637,6 +4330,15 @@
                 }
             }
         },
+        "ssri": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+            "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
         "stdout-stream": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
@@ -5656,6 +4358,16 @@
                 "readable-stream": "2.3.3"
             }
         },
+        "stream-each": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+            "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.0",
+                "stream-shift": "1.0.0"
+            }
+        },
         "stream-http": {
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
@@ -5669,10 +4381,10 @@
                 "xtend": "4.0.1"
             }
         },
-        "strict-uri-encode": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
             "dev": true
         },
         "string-width": {
@@ -5734,41 +4446,11 @@
                 "get-stdin": "4.0.1"
             }
         },
-        "style-loader": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.0.tgz",
-            "integrity": "sha512-9mx9sC9nX1dgP96MZOODpGC6l1RzQBITI2D5WJhu+wnbrSYVKLGuy14XJSLVQih/0GFrPpjelt+s//VcZQ2Evw==",
-            "dev": true,
-            "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.3.0"
-            }
-        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
-        },
-        "svgo": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-            "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-            "dev": true,
-            "requires": {
-                "coa": "1.0.4",
-                "colors": "1.1.2",
-                "csso": "2.3.2",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "sax": "1.2.4",
-                "whet.extend": "0.9.9"
-            }
-        },
-        "symbol-observable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-            "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
         },
         "tapable": {
             "version": "0.2.8",
@@ -5785,6 +4467,16 @@
                 "block-stream": "0.0.9",
                 "fstream": "1.0.11",
                 "inherits": "2.0.3"
+            }
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
             }
         },
         "timers-browserify": {
@@ -5807,14 +4499,6 @@
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
             "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
             "dev": true
-        },
-        "topojson-client": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
-            "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
-            "requires": {
-                "commander": "2.12.1"
-            }
         },
         "tough-cookie": {
             "version": "2.3.3",
@@ -5880,6 +4564,12 @@
             "dev": true,
             "optional": true
         },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -5942,29 +4632,26 @@
             "requires": {
                 "source-map": "0.5.7",
                 "uglify-js": "2.8.29",
-                "webpack-sources": "1.0.2"
+                "webpack-sources": "1.1.0"
             }
         },
-        "uniq": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-            "dev": true
-        },
-        "uniqid": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-            "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+        "unique-filename": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+            "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
             "dev": true,
             "requires": {
-                "macaddress": "0.2.8"
+                "unique-slug": "2.0.0"
             }
         },
-        "uniqs": {
+        "unique-slug": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-            "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+            "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "0.1.4"
+            }
         },
         "url": {
             "version": "0.11.0",
@@ -6023,12 +4710,6 @@
                 "spdx-expression-parse": "1.0.4"
             }
         },
-        "vendors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-            "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
-            "dev": true
-        },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -6048,49 +4729,6 @@
                 }
             }
         },
-        "victory": {
-            "version": "0.22.2",
-            "resolved": "https://registry.npmjs.org/victory/-/victory-0.22.2.tgz",
-            "integrity": "sha1-0MGrjHfZzQtDvRW6aD8SUNrnuns=",
-            "requires": {
-                "victory-chart": "22.0.0",
-                "victory-core": "18.0.2",
-                "victory-pie": "12.0.0"
-            }
-        },
-        "victory-chart": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-22.0.0.tgz",
-            "integrity": "sha1-VfCoXH0U1Ph6tQt2GvDsFzF3Pms=",
-            "requires": {
-                "d3-voronoi": "1.1.2",
-                "lodash": "4.17.4",
-                "victory-core": "18.0.2"
-            }
-        },
-        "victory-core": {
-            "version": "18.0.2",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-18.0.2.tgz",
-            "integrity": "sha1-WpYoZdHOR7HOx0CjSjn4J0ttTmg=",
-            "requires": {
-                "d3-ease": "1.0.3",
-                "d3-interpolate": "1.1.6",
-                "d3-scale": "1.0.6",
-                "d3-shape": "1.2.0",
-                "d3-timer": "1.0.7",
-                "lodash": "4.17.4"
-            }
-        },
-        "victory-pie": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-12.0.0.tgz",
-            "integrity": "sha1-YMc00pdr4tARRG/fqQJOClkipgU=",
-            "requires": {
-                "d3-shape": "1.2.0",
-                "lodash": "4.17.4",
-                "victory-core": "18.0.2"
-            }
-        },
         "vm-browserify": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -6104,6 +4742,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
             "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+            "dev": true,
             "requires": {
                 "loose-envify": "1.3.1"
             }
@@ -6120,19 +4759,19 @@
             }
         },
         "webpack": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-            "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+            "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
             "dev": true,
             "requires": {
-                "acorn": "5.2.1",
+                "acorn": "5.3.0",
                 "acorn-dynamic-import": "2.0.2",
-                "ajv": "5.4.0",
+                "ajv": "5.5.2",
                 "ajv-keywords": "2.1.1",
                 "async": "2.6.0",
                 "enhanced-resolve": "3.4.1",
                 "escope": "3.6.0",
-                "interpret": "1.0.4",
+                "interpret": "1.1.0",
                 "json-loader": "0.5.7",
                 "json5": "0.5.1",
                 "loader-runner": "2.3.0",
@@ -6145,7 +4784,7 @@
                 "tapable": "0.2.8",
                 "uglifyjs-webpack-plugin": "0.4.6",
                 "watchpack": "1.4.0",
-                "webpack-sources": "1.0.2",
+                "webpack-sources": "1.1.0",
                 "yargs": "8.0.2"
             },
             "dependencies": {
@@ -6299,9 +4938,9 @@
             }
         },
         "webpack-sources": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
-            "integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+            "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "dev": true,
             "requires": {
                 "source-list-map": "2.0.0",
@@ -6320,12 +4959,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
             "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-        },
-        "whet.extend": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-            "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
-            "dev": true
         },
         "which": {
             "version": "1.3.0",
@@ -6377,11 +5010,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xmlhttprequest": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-            "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
         },
         "xtend": {
             "version": "4.0.1",

--- a/samples/widgets/WidgetState/package-lock.json
+++ b/samples/widgets/WidgetState/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.0.0.tgz",
-            "integrity": "sha1-yaeAXvIm70xt0eHuToGc5QQ/2lI="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.1.0.tgz",
+            "integrity": "sha1-oKr/QZzEcED8PvdifuZeWxKVYCY="
         },
         "abbrev": {
             "version": "1.1.1",

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package-lock.json
@@ -5032,11 +5032,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",
@@ -5046,13 +5047,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.6.18",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package-lock.json
@@ -5032,11 +5032,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",
@@ -5046,13 +5047,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.6.18",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package-lock.json
@@ -5032,11 +5032,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",
@@ -5046,13 +5047,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.6.18",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package-lock.json
@@ -5032,9 +5032,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.17",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.17.tgz",
+            "integrity": "sha512-u3nnP1nC02kz1/U+AWtj1gZOh9eMk1arfm3/AJfJNzJUOCw0tMM6UljlduB28SWL3pNXshoyfC7ZyRbXLb7u+Q==",
             "requires": {
                 "d3": "4.12.0",
                 "prop-types": "15.6.0",
@@ -5046,13 +5046,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "0.6.17",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package-lock.json
@@ -5032,11 +5032,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",
@@ -5046,13 +5047,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.6.18",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package-lock.json
@@ -5032,11 +5032,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",
@@ -5046,13 +5047,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.6.18",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "0.6.17",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package-lock.json
@@ -5032,11 +5032,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
+            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",
@@ -5046,13 +5047,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.6.18",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package-lock.json
@@ -5032,9 +5032,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.3.tgz",
-            "integrity": "sha512-yZg4p0uqmW/K1VsSxORxuTwAEL7fiWHPxpGPwVfw9cVBzFUtDw4y9wPnaQYjZhAqbr4UhdqNvBbEi72BazUhiA==",
+            "version": "0.6.17",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.17.tgz",
+            "integrity": "sha512-u3nnP1nC02kz1/U+AWtj1gZOh9eMk1arfm3/AJfJNzJUOCw0tMM6UljlduB28SWL3pNXshoyfC7ZyRbXLb7u+Q==",
             "requires": {
                 "d3": "4.12.0",
                 "prop-types": "15.6.0",
@@ -5046,13 +5046,13 @@
                 "react-tooltip": "3.4.0",
                 "topojson-client": "3.0.0",
                 "victory": "0.22.2",
-                "victory-core": "20.3.0"
+                "victory-core": "20.6.0"
             },
             "dependencies": {
                 "victory-core": {
-                    "version": "20.3.0",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.3.0.tgz",
-                    "integrity": "sha512-Gc35igFq6MeXz4ZDO76iaxmoeTvULuPJ1nbRS6RS6M2KhldT5/gk7TwmuYhO5O46swMXosZDGt3QWhOFDCZpyg==",
+                    "version": "20.6.0",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
+                    "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
                     "requires": {
                         "d3-ease": "1.0.3",
                         "d3-interpolate": "1.1.6",

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "0.6.17",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"


### PR DESCRIPTION
## Purpose
Upgrade react-Vizgrammer version to 0.6.18 for weekly release.

## Goals
Upgrade react-Vizgrammer version to 0.6.18 for weekly release.

## Approach
Upgrade react-Vizgrammer version to 0.6.18 for weekly release. Since there are some issues with the pie charts, these widgets are only upgraded into 0.6.17

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
NA
 
## Learning
NA