### PR TITLE
Remove apache commons fileupload vulnerable jar from shindig

### DIFF
--- a/components/shindig-server/pom.xml
+++ b/components/shindig-server/pom.xml
@@ -71,6 +71,7 @@
                         <configuration>
                             <tasks>
                                 <property name="tempdir" value="target/temp" />
+                                <property name="apache.commons.fileupload.version" value="1.3.1"/>
                                 <unzip dest="${tempdir}/shindig">
                                     <fileset dir="target/">
                                         <include name="shindig-server-${carbon.dashboards.version}.war" />
@@ -93,6 +94,8 @@
                                     <fileset dir="src/main/resources" includes="error-pages/**">
                                     </fileset>
                                 </copy>
+                                <!--apache-commons-fileupload.1.3.1.jar is a vulnerable jar. It is removed here-->
+                                <delete file="${tempdir}/shindig/WEB-INF/lib/commons-fileupload-${apache.commons.fileupload.version}.jar" />
                                 <zip destfile="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}.jar" basedir="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}" />
                                 <delete dir="${tempdir}/shindig/WEB-INF/lib/shindig-extras-${shindig.version}" />
                                 <zip destfile="target/shindig-server-${carbon.dashboards.version}.war" basedir="${tempdir}/shindig" />


### PR DESCRIPTION
## Purpose
> There is a vulnerability CVE-2016-3092 in the apache-commons-fileupload.1.3.1.jar file. This is packed to carbon-dashboard via shindig server. We have removed that from this fix so that it will be taken from the fileupload jar in our plugins of the carbon-pack

## Goals
> Fix the vulnerability issue.

## Approach
> Remove the jar and zip it back
## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
N/A

## Security checks
N/A
## Samples
> N/A
## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A