### PR TITLE
Remove org.wso2.carbon.dashboards.samples.widgets.universal-widget dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,12 +344,6 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.dashboards.samples.widgets</groupId>
-                <artifactId>org.wso2.carbon.dashboards.samples.widgets.universal-widget</artifactId>
-                <version>${carbon.dashboards.version}</version>
-                <type>zip</type>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.dashboards.samples.widgets</groupId>
                 <artifactId>org.wso2.carbon.dashboards.samples.widgets.user-info</artifactId>
                 <version>${carbon.dashboards.version}</version>
                 <type>zip</type>

--- a/samples/features/org.wso2.carbon.dashboards.samples.feature/pom.xml
+++ b/samples/features/org.wso2.carbon.dashboards.samples.feature/pom.xml
@@ -128,11 +128,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.dashboards.samples.widgets</groupId>
-            <artifactId>org.wso2.carbon.dashboards.samples.widgets.universal-widget</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.dashboards.samples.widgets</groupId>
             <artifactId>org.wso2.carbon.dashboards.samples.widgets.user-info</artifactId>
             <type>zip</type>
         </dependency>


### PR DESCRIPTION
## Purpose
$subject, as `org.wso2.carbon.dashboards.samples.widgets.universal-widget` does not exists any more

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
