### PR TITLE
Fix the bug where widget configuration panel does not appear for widgets with different id and name property

### DIFF
--- a/components/dashboards-web-component/src/designer/components/WidgetConfigurationPane.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetConfigurationPane.jsx
@@ -93,7 +93,7 @@ export default class WidgetConfigurationPane extends Component {
         const renderingWidgetNames =
             GoldenLayoutContentUtils.getReferredWidgetNames(this.props.selectedPageGoldenLayoutContent);
         return renderingWidgetNames.map((widgetName) => {
-            return this.props.allWidgetsConfigurations.find(widgetConfig => (widgetConfig.id === widgetName));
+            return this.props.allWidgetsConfigurations.find(widgetConfig => (widgetConfig.name === widgetName));
         });
     }
 
@@ -110,7 +110,7 @@ export default class WidgetConfigurationPane extends Component {
     getSelectedWidgetConfiguration() {
         const selectedWidgetName = this.props.selectedWidgetGoldenLayoutContent.config.title;
         return this.getSelectedPageAllWidgetsConfigurations().find((widgetConfiguration) => {
-            return (widgetConfiguration.id === selectedWidgetName);
+            return (widgetConfiguration.name === selectedWidgetName);
         });
     }
 


### PR DESCRIPTION
## Purpose
$subject

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes