### PR TITLE
Fix for WidgetChannelManager not working in Preview Widget of Chart Generation Wizard

### DIFF
--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPreview/PreviewerWidget.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/chartPreview/PreviewerWidget.jsx
@@ -15,13 +15,12 @@
 */
 import React from 'react';
 import VizG from 'react-vizgrammar';
-import WidgetChannelManager from './WidgetChannelManager';
+import widgetChannelManager from './WidgetChannelManager';
 
 export default class PreviewerWidget extends React.Component {
 
     constructor(props) {
         super(props);
-        this.channelManager = new WidgetChannelManager();
         this.state = {
             data: [],
             metadata: null,
@@ -31,11 +30,11 @@ export default class PreviewerWidget extends React.Component {
 
     componentDidMount() {
         let { config } = this.props;
-        this.channelManager.subscribeWidget(config.id, this._handleDataReceived, config.configs.providerConfig);
+        widgetChannelManager.subscribeWidget(config.id, this._handleDataReceived, config.configs.providerConfig);
     }
 
     componentWillUnmount() {
-        this.channelManager.unsubscribeWidget(this.props.config.id);
+        widgetChannelManager.unsubscribeWidget(this.props.config.id);
     }
 
     _handleDataReceived(data) {


### PR DESCRIPTION
## Purpose
Fix for WidgetChannelManager not working in Preview Widget of Chart Generation Wizard

## Test environment
Node JS v8.8.1, NPM v5.4.2