### PR TITLE
Fix faulty redirection on login

### DIFF
--- a/components/dashboards-web-component/src/auth/Login.jsx
+++ b/components/dashboards-web-component/src/auth/Login.jsx
@@ -58,7 +58,7 @@ export default class Login extends Component {
             password: '',
             authenticated: false,
             rememberMe: false,
-            referrer: window.contextPath,
+            referrer: '/',
         };
         this.authenticate = this.authenticate.bind(this);
     }

--- a/components/dashboards-web-component/src/auth/Logout.jsx
+++ b/components/dashboards-web-component/src/auth/Logout.jsx
@@ -27,15 +27,27 @@ import AuthManager from './utils/AuthManager';
  * Logout.
  */
 export default class Logout extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            redirectToLogin: false
+        }
+    }
+
+    componentDidMount() {
+        DashboardThumbnail.deleteDashboardThumbnails();
+        AuthManager.logout()
+            .then(() => this.setState({ redirectToLogin: true }));
+    }
+
     /**
      * Renders logout component.
      * @returns {XML} HTML content
      */
     render() {
-        DashboardThumbnail.deleteDashboardThumbnails();
-        AuthManager.logout();
-        return (
-            <Redirect to={{ pathname: '/login' }} />
-        );
+        if (this.state.redirectToLogin) {
+            return <Redirect to={{ pathname: '/login' }} />;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Purpose
In carbon-dashboards 4.0.17, following issues happen when a user tries to login after logout.

1. Login page refreshes when the use key-presses on username field for the first time.
2. After successful login, the user gets redirected to `http://localhost:9643/portal/portal` instead of the dashboard listing page.

Resolves https://github.com/wso2/carbon-dashboards/issues/922

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes