### PR TITLE
Add support for theme Dashboard theme change in Universal Widget

### DIFF
--- a/components/universal-widget/src/UniversalWidget.jsx
+++ b/components/universal-widget/src/UniversalWidget.jsx
@@ -130,6 +130,7 @@ export default class UniversalWidget extends Widget {
                     height={this.props.glContainer.height}
                     width={this.props.glContainer.width}
                     onClick={this.state.config && this.state.config.widgetOutputConfigs ? this.publishEvents : ""}
+                    theme={this.props.muiTheme.name}
                 />
             </div>
         )


### PR DESCRIPTION
## Purpose
This will enable the Universal Widget to change it's theme with the Dashboard Theme change.

## Test environment
Node.JS v8.8.1, NPM v5.4.2