### PR TITLE
Adding getWidgetConfiguration API to base-widget

### DIFF
--- a/base-widget/package-lock.json
+++ b/base-widget/package-lock.json
@@ -58,6 +58,15 @@
       "dev": true,
       "optional": true
     },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "requires": {
+        "follow-redirects": "1.5.0",
+        "is-buffer": "1.1.6"
+      }
+    },
     "babel-cli": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
@@ -954,6 +963,24 @@
         "locate-path": "2.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1086,8 +1113,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -1305,8 +1331,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "normalize-path": {
       "version": "2.1.1",

--- a/base-widget/package.json
+++ b/base-widget/package.json
@@ -25,5 +25,7 @@
   "bugs": {
     "url": "https://github.com/npm/npm/issues"
   },
-  "dependencies": {}
+  "dependencies": {
+    "axios": "^0.17.1"
+  }
 }

--- a/base-widget/src/Widget.jsx
+++ b/base-widget/src/Widget.jsx
@@ -18,6 +18,7 @@
 
 import React, {Component} from 'react';
 import WidgetChannelManager from './WidgetChannelManager';
+import Axios from 'axios';
 
 const SESSION_USER = 'DASHBOARD_USER';
 
@@ -177,6 +178,16 @@ export default class Widget extends Component {
 
     getWidgetChannelManager() {
         return WidgetChannelManager;
+    }
+
+    getWidgetConfiguration(widgetId) {
+        let httpClient = Axios.create({
+            baseURL: window.location.origin + window.contextPath,
+            timeout: 2000,
+            headers: {"Authorization": "Bearer " + JSON.parse(Widget._getSessionCookie(SESSION_USER)).SDID},
+        });
+        httpClient.defaults.headers.post['Content-Type'] = 'application/json';
+        return httpClient.get(`/apis/widgets/${widgetId}`);
     }
 }
 


### PR DESCRIPTION
## Purpose
Custom widgets the should be able to get the widget configurations 

## Goals
Introduce getWidgetConfiguration API to get the widget configuration

## Approach
The API will return httpClient.get function, which can then be used to access the widget configurations

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A
