### PR TITLE
Bump versions of react-vizgrammar and base-widget

### DIFF
--- a/components/dashboards-web-component/package-lock.json
+++ b/components/dashboards-web-component/package-lock.json
@@ -5,9 +5,23 @@
   "requires": true,
   "dependencies": {
     "@wso2-dashboards/widget": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-      "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+      "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+      "requires": {
+        "axios": "0.17.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+          "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+          "requires": {
+            "follow-redirects": "1.2.6",
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
     },
     "abbrev": {
       "version": "1.1.1",
@@ -2434,7 +2448,7 @@
     "d3": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
-      "integrity": "sha1-qyNv+M8M/CeoHmm/L7dRi8m08z0=",
+      "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
       "requires": {
         "d3-array": "1.2.1",
         "d3-axis": "1.0.8",
@@ -2471,12 +2485,12 @@
         "d3-format": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-          "integrity": "sha1-GjnEecilf+UFGy5no77icGGnTno="
+          "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
         },
         "d3-scale": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-          "integrity": "sha1-+pAySz6op3ZCK9BHKvqwslKglF0=",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
           "requires": {
             "d3-array": "1.2.1",
             "d3-collection": "1.0.4",
@@ -2538,7 +2552,7 @@
     "d3-drag": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
-      "integrity": "sha1-343UxQL7SQ/HRiBGqK2YpcR5KC0=",
+      "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
       "requires": {
         "d3-dispatch": "1.0.3",
         "d3-selection": "1.3.0"
@@ -2547,7 +2561,7 @@
     "d3-dsv": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
-      "integrity": "sha1-kH4kDVezhmGNxWRous/na/GXZK4=",
+      "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
       "requires": {
         "commander": "2.12.2",
         "iconv-lite": "0.4.19",
@@ -2562,7 +2576,7 @@
     "d3-force": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-      "integrity": "sha1-zr88aU8QePzD1Nr45Wey+9cNTqM=",
+      "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
       "requires": {
         "d3-collection": "1.0.4",
         "d3-dispatch": "1.0.3",
@@ -2578,7 +2592,7 @@
     "d3-geo": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
-      "integrity": "sha1-FX47D5FzedD3O+v/875Tf0n6c1Y=",
+      "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
       "requires": {
         "d3-array": "1.2.1"
       }
@@ -2634,7 +2648,7 @@
     "d3-request": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-      "integrity": "sha1-oQRKnvTsKMgkFxyTefrm15R0sZ8=",
+      "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
       "requires": {
         "d3-collection": "1.0.4",
         "d3-dispatch": "1.0.3",
@@ -2659,7 +2673,7 @@
     "d3-selection": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-      "integrity": "sha1-1TdyOC09xPdQe/sovNLWrtKgrW0="
+      "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
     },
     "d3-shape": {
       "version": "1.2.0",
@@ -2685,12 +2699,12 @@
     "d3-timer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-      "integrity": "sha1-35ZQylh/bJZgf/TmDMOCKejdhTE="
+      "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
     },
     "d3-transition": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
-      "integrity": "sha1-2O+Jw7hIc1sGDlSjmzKq66pCEDk=",
+      "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
       "requires": {
         "d3-color": "1.0.3",
         "d3-dispatch": "1.0.3",
@@ -2708,7 +2722,7 @@
     "d3-zoom": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
-      "integrity": "sha1-AvQ7PD4ttU82RYLX5KI2zMVQa2M=",
+      "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
       "requires": {
         "d3-dispatch": "1.0.3",
         "d3-drag": "1.2.1",
@@ -7909,21 +7923,21 @@
       }
     },
     "rc-align": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.0.tgz",
-      "integrity": "sha512-rx8jrgASa1RJnVbwYfFYF0mp4BAkhc9yitf6kZHuT1pmsMWMofK5FQIg4wWwVde5lwU320YFJbRGXd03Ii4c+Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.1.tgz",
+      "integrity": "sha512-rKl7lFhpCVH/nmELrHRzqMGRRmIpUDO93tmXRzRrWjTfpMwpz94NA+zEXk+ZLKQc+sYP+CAcdoF65Wq6FUAH/A==",
       "requires": {
         "babel-runtime": "6.26.0",
         "dom-align": "1.7.0",
         "prop-types": "15.6.0",
-        "rc-util": "4.5.0",
+        "rc-util": "4.5.1",
         "shallowequal": "1.0.2"
       }
     },
     "rc-animate": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.4.tgz",
-      "integrity": "sha1-oFp4THR77vFA2Z/1K2EXcRvvSx4=",
+      "integrity": "sha512-DjJLTUQj7XKKcuS8cczN0uOLfuSmgrVXFGieP1SZc87xUUTFGh8B/KjNmEtlfvxkSrSuVfb2rrEPER4SqKUtEA==",
       "requires": {
         "babel-runtime": "6.26.0",
         "css-animation": "1.4.1",
@@ -7939,7 +7953,7 @@
         "classnames": "2.2.5",
         "prop-types": "15.6.0",
         "rc-tooltip": "3.7.2",
-        "rc-util": "4.5.0",
+        "rc-util": "4.5.1",
         "shallowequal": "1.0.2",
         "warning": "3.0.0"
       }
@@ -7951,25 +7965,33 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "prop-types": "15.6.0",
-        "rc-trigger": "2.5.1"
+        "rc-trigger": "2.5.3"
       }
     },
     "rc-trigger": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.5.1.tgz",
-      "integrity": "sha512-YWfHr1p0U1ZbqJOiGmEH3D+RBlW2VdsNq/QLjXxhhmKtkzJL2cyEJQnZJGG0lyqPZOD2yXNQYD06vv0wmc6Iiw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.5.3.tgz",
+      "integrity": "sha512-geHPrEm7asNVhdDwfEv0rJIYN3rZ95M3myVk1MPdNv+qRk+9REaNT5Aez01Ia3SA35+RkR1KGF2GMp4XMyKZgA==",
       "requires": {
         "babel-runtime": "6.26.0",
+        "classnames": "2.2.6",
         "prop-types": "15.6.0",
-        "rc-align": "2.4.0",
+        "rc-align": "2.4.1",
         "rc-animate": "2.4.4",
-        "rc-util": "4.5.0"
+        "rc-util": "4.5.1"
+      },
+      "dependencies": {
+        "classnames": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+        }
       }
     },
     "rc-util": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.5.0.tgz",
-      "integrity": "sha512-KYuFBBqxCFI8fb4Wva+X3fmAZpGPo4i9gTNdsVKldHVi3hrnv3VawF89CPndxfsV5QT3J+ic76X5c4erQETi1w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.5.1.tgz",
+      "integrity": "sha512-PdCmHyBBodZdw6Oaikt0l+/R79IcRXpYkTrqD/Rbl4ZdoOi61t5TtEe40Q+A7rkWG5U1xjcN+h8j9H6GdtnICw==",
       "requires": {
         "add-dom-event-listener": "1.0.2",
         "babel-runtime": "6.26.0",
@@ -8127,7 +8149,7 @@
     "react-simple-maps": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-0.9.0.tgz",
-      "integrity": "sha1-pej0/JWJLs86UQBCdrpD7RacTRg=",
+      "integrity": "sha512-6nH0VUB1z+kwsgChZo3E+jc2uWp9MdTqut+SSTiEFXlWfeRgG4Nc0/YkSOIZUwbGCoEpPsdpQDaoaMspQcC+uw==",
       "requires": {
         "d3-geo": "1.6.3",
         "d3-geo-projection": "1.2.2",
@@ -8226,9 +8248,9 @@
       }
     },
     "react-vizgrammar": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.11.tgz",
-      "integrity": "sha512-7w6f11kvrgkwe5ZBvkMCWgNuT7s74AmIUmRWi4UT6Cv7l8igvFBWVUQ8WSJjsWZhJeKmCrcii5o3UTol5kIGxw==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+      "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
       "requires": {
         "d3": "4.13.0",
         "lodash": "4.17.5",
@@ -9087,7 +9109,7 @@
     "shallowequal": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-      "integrity": "sha1-FWHb3vuMAUCBADGQhXZNo/z4P48="
+      "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -10450,7 +10472,7 @@
     "victory-core": {
       "version": "20.6.0",
       "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-20.6.0.tgz",
-      "integrity": "sha1-X19KxDNkyQJdu/vNl6Lz/rP59q0=",
+      "integrity": "sha512-ucE3AWR3HaQIWLfAl/vQI+QfYbwgIFSgai2VnfxPZFoeyZ1QjR7qJC3AyhrHaE1r1K8Wcl3XeWtDT42Bu6yYEw==",
       "requires": {
         "d3-ease": "1.0.3",
         "d3-interpolate": "1.1.6",

--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/wso2/carbon-dashboards#readme",
   "dependencies": {
-    "@wso2-dashboards/widget": "^1.2.0",
+    "@wso2-dashboards/widget": "^1.2.2",
     "axios": "^0.16.2",
     "babel-polyfill": "^6.26.0",
     "brace": "^0.11.0",
@@ -40,7 +40,7 @@
     "react-shadow": "^2.0.2",
     "react-speed-dial": "^0.4.7",
     "react-tooltip": "^3.4.0",
-    "react-vizgrammar": "^0.7.11",
+    "react-vizgrammar": "^0.7.14",
     "recharts": "^1.0.0-alpha.2"
   },
   "devDependencies": {

--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -215,6 +215,7 @@ export default class WidgetRenderer extends Component {
     }
 
     render() {
+        console.info('WidgetRenderer', getWidgetChannelManager());
         if (this.state.widgetLoadingStatus === WidgetLoadingStatus.LOADED) {
             if (this.state.reRenderWidget) {
                 setTimeout(() => this.setState({ reRenderWidget: false }), 50);

--- a/components/universal-widget/package-lock.json
+++ b/components/universal-widget/package-lock.json
@@ -5,9 +5,12 @@
   "requires": true,
   "dependencies": {
     "@wso2-dashboards/widget": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-      "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+      "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+      "requires": {
+        "axios": "0.17.1"
+      }
     },
     "abbrev": {
       "version": "1.1.1",
@@ -4764,14 +4767,14 @@
       }
     },
     "rc-align": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.0.tgz",
-      "integrity": "sha512-rx8jrgASa1RJnVbwYfFYF0mp4BAkhc9yitf6kZHuT1pmsMWMofK5FQIg4wWwVde5lwU320YFJbRGXd03Ii4c+Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.1.tgz",
+      "integrity": "sha512-rKl7lFhpCVH/nmELrHRzqMGRRmIpUDO93tmXRzRrWjTfpMwpz94NA+zEXk+ZLKQc+sYP+CAcdoF65Wq6FUAH/A==",
       "requires": {
         "babel-runtime": "6.26.0",
         "dom-align": "1.7.0",
         "prop-types": "15.6.0",
-        "rc-util": "4.5.0",
+        "rc-util": "4.5.1",
         "shallowequal": "1.0.2"
       }
     },
@@ -4794,7 +4797,7 @@
         "classnames": "2.2.5",
         "prop-types": "15.6.0",
         "rc-tooltip": "3.7.2",
-        "rc-util": "4.5.0",
+        "rc-util": "4.5.1",
         "shallowequal": "1.0.2",
         "warning": "3.0.0"
       }
@@ -4806,25 +4809,33 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "prop-types": "15.6.0",
-        "rc-trigger": "2.5.1"
+        "rc-trigger": "2.5.3"
       }
     },
     "rc-trigger": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.5.1.tgz",
-      "integrity": "sha512-YWfHr1p0U1ZbqJOiGmEH3D+RBlW2VdsNq/QLjXxhhmKtkzJL2cyEJQnZJGG0lyqPZOD2yXNQYD06vv0wmc6Iiw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.5.3.tgz",
+      "integrity": "sha512-geHPrEm7asNVhdDwfEv0rJIYN3rZ95M3myVk1MPdNv+qRk+9REaNT5Aez01Ia3SA35+RkR1KGF2GMp4XMyKZgA==",
       "requires": {
         "babel-runtime": "6.26.0",
+        "classnames": "2.2.6",
         "prop-types": "15.6.0",
-        "rc-align": "2.4.0",
+        "rc-align": "2.4.1",
         "rc-animate": "2.4.4",
-        "rc-util": "4.5.0"
+        "rc-util": "4.5.1"
+      },
+      "dependencies": {
+        "classnames": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+        }
       }
     },
     "rc-util": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.5.0.tgz",
-      "integrity": "sha512-KYuFBBqxCFI8fb4Wva+X3fmAZpGPo4i9gTNdsVKldHVi3hrnv3VawF89CPndxfsV5QT3J+ic76X5c4erQETi1w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.5.1.tgz",
+      "integrity": "sha512-PdCmHyBBodZdw6Oaikt0l+/R79IcRXpYkTrqD/Rbl4ZdoOi61t5TtEe40Q+A7rkWG5U1xjcN+h8j9H6GdtnICw==",
       "requires": {
         "add-dom-event-listener": "1.0.2",
         "babel-runtime": "6.26.0",
@@ -4945,9 +4956,9 @@
       }
     },
     "react-vizgrammar": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.12.tgz",
-      "integrity": "sha512-He0jc/c/h4cZ/SqrQTyYmGJOY0vL22A6INZFlpq49r3PwqYb5ZOdpjTXESTrmyBN2wxRREPugyrpaU0Yw+Bl0Q==",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.13.tgz",
+      "integrity": "sha512-80giqQehFaTKzytCKTxRsmqoGrdNZYTdlegqjako5ocMVF4VVGdUnhIfJPYQN5h1PzivYspomtzosQlkaZUfsQ==",
       "requires": {
         "d3": "4.13.0",
         "lodash": "4.17.4",

--- a/components/universal-widget/package.json
+++ b/components/universal-widget/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@wso2-dashboards/widget": "^1.2.0",
+    "@wso2-dashboards/widget": "^1.2.2",
     "axios": "^0.17.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-vizgrammar": "^0.7.12",
+    "react-vizgrammar": "^0.7.14",
     "rimraf": "^2.6.2"
   },
   "scripts": {

--- a/components/universal-widget/src/UniversalWidget.jsx
+++ b/components/universal-widget/src/UniversalWidget.jsx
@@ -59,6 +59,7 @@ export default class UniversalWidget extends Widget {
                     this.handleCustomWidgetInputs(providerConfiguration.configs.config.queryData)
                 }
                 this.state.providerConfigs = providerConfiguration;
+                console.info(super.getWidgetChannelManager());
                 super.getWidgetChannelManager().
                     subscribeWidget(this.props.id, this.handleWidgetData, providerConfiguration);
                 this.setState({ config: message.data.configs.chartConfig, metadata: message.data.configs.metadata });
@@ -100,7 +101,7 @@ export default class UniversalWidget extends Widget {
                 this.state.widgetInputs.push(receivedData[widgetInputOutputMapping.publisherWidgetOutput]);
             }
         });
-        eval(this.state.queryData.queryFunction)
+        eval(this.state.queryData.queryFunction);
         this.state.providerConfigs.configs.config.queryData.query = this.getQuery.apply(this, this.state.widgetInputs);
         super.getWidgetChannelManager().unsubscribeWidget(this.props.id);
         super.getWidgetChannelManager().

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,9 +5060,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
-            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
                 "lodash": "4.17.4",

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.18",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/src/CustomersByProduct.jsx
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/src/CustomersByProduct.jsx
@@ -45,7 +45,8 @@ class CustomersByProduct extends Widget {
                 legendTitleColor: "#5d6e77",
                 legendTextColor: "#5d6e77",
                 tickLabelColor: "#5d6e77",
-                axisLabelColor: "#5d6e77"
+                axisLabelColor: "#5d6e77",
+                legendTextSize: 14,
             },
             gridColor: "#5d6e77"
         };

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,9 +5060,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
-            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
                 "lodash": "4.17.4",

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.18",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/src/CustomersPerYear.jsx
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/src/CustomersPerYear.jsx
@@ -44,7 +44,8 @@ class CustomersPerYear extends Widget {
                 legendTitleColor: "#5d6e77",
                 legendTextColor: "#5d6e77",
                 tickLabelColor: "#5d6e77",
-                axisLabelColor: "#5d6e77"
+                axisLabelColor: "#5d6e77",
+                legendTextSize: 14,
             },
             gridColor: "#5d6e77"
         };

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,9 +5060,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
-            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
                 "lodash": "4.17.4",

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.18",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,11 +5060,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.17",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.17.tgz",
-            "integrity": "sha512-u3nnP1nC02kz1/U+AWtj1gZOh9eMk1arfm3/AJfJNzJUOCw0tMM6UljlduB28SWL3pNXshoyfC7ZyRbXLb7u+Q==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.17",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,9 +5060,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
-            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
                 "lodash": "4.17.4",

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.18",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/src/RevenueByCountry.jsx
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/src/RevenueByCountry.jsx
@@ -86,8 +86,9 @@ class RevenueByCountry extends Widget {
     }
 
     setSelectedCountry(selected) {
-        super.publish({"CountryName": selected.givenName, "CountryCode": selected.x, "revenue": selected.y});
-        this.setState({selectedCountry: selected.givenName, selectedRev: selected.y});
+        let key = Object.keys(selected)[0];
+        super.publish({"CountryCode": key, "revenue": selected[key]});
+        this.setState({selectedCountry: key, selectedRev: selected[key]});
     }
 
     handleResize() {

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/src/style.css
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/src/style.css
@@ -1,0 +1,3 @@
+.iconClass svg {
+    fill: #d3d3d3;
+}

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,9 +5060,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
-            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
                 "lodash": "4.17.4",

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.18",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProductWithUserPreferences/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProductWithUserPreferences/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,9 +5060,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.20",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.20.tgz",
-            "integrity": "sha512-XC43KeDPeN4w3Nw5fEzMjB1MklBpQCqR4fsriP51S5zqoZLCKzwUU5WkmsIO3fsEweP86DIrG6MkBZa0ooNNLw==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
                 "lodash": "4.17.4",

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProductWithUserPreferences/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProductWithUserPreferences/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "lodash": "^4.17.4",
         "material-ui": "^0.19.4",
@@ -14,7 +14,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.9",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,11 +5060,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.17",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.17.tgz",
-            "integrity": "sha512-u3nnP1nC02kz1/U+AWtj1gZOh9eMk1arfm3/AJfJNzJUOCw0tMM6UljlduB28SWL3pNXshoyfC7ZyRbXLb7u+Q==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.17",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/src/RevenueByRegion.jsx
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/src/RevenueByRegion.jsx
@@ -17,13 +17,14 @@
  *
  */
 
-import React, {Component} from 'react';
+import React from 'react';
 import VizG from 'react-vizgrammar';
 import Widget from '@wso2-dashboards/widget';
 
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import RevertIcon from 'material-ui/svg-icons/action/cached';
 import FlatButton from 'material-ui/FlatButton';
+import IconButton from 'material-ui/IconButton';
 
 class RevenueByRegion extends Widget {
     constructor(props) {
@@ -160,7 +161,7 @@ class RevenueByRegion extends Widget {
             width: props.glContainer.width,
             height: props.glContainer.height,
             animate: true,
-            style: {legendTitleColor: "#5d6e77", legendTextColor: "#5d6e77"}
+            style: {legendTitleColor: "#5d6e77", legendTextColor: "#5d6e77", legendTextSize: 14}
         };
 
         this.configPieProduct = {
@@ -174,7 +175,7 @@ class RevenueByRegion extends Widget {
             width: props.glContainer.width,
             height: props.glContainer.height,
             animate: true,
-            style: {legendTitleColor: "#5d6e77", legendTextColor: "#5d6e77"}
+            style: {legendTitleColor: "#5d6e77", legendTextColor: "#5d6e77", legendTextSize: 14}
         };
 
         this.aggregatedData = [
@@ -208,14 +209,15 @@ class RevenueByRegion extends Widget {
     }
 
     handleClickEvent(event) {
+        let key = Object.keys(event)[0];
         if (!this.state.isDrillDowned) {
             let array = [];
             this.rowdata.map(data => {
-                if (data[2] === event.datum.x) {
+                if (data[2] === key) {
                     array.push(data)
                 }
             });
-            super.publish({selectedRegion: event.datum.x});
+            super.publish({selectedRegion: key});
             this.setState({config: this.configPieProduct, data: array, isDrillDowned: true});
         } else {
             super.publish({selectedRegion: "ALL"});
@@ -226,14 +228,17 @@ class RevenueByRegion extends Widget {
     render() {
         return (
             <MuiThemeProvider>
-                <FlatButton
-                    backgroundColor="steelblue"
-                    hoverColor="#536DFE"
-                    icon={<RevertIcon style={{margin: "10px"}}/>}
-                    style={{marginLeft: "10px", minWidth: 0}}
+                <IconButton
                     onClick={this.handleClickEvent}
                     disabled={!this.state.isDrillDowned}
-                />
+                    iconStyle={{
+                        color: '#fff',
+                        cursor: 'default',
+                        fill: '#fff',
+                    }}
+                >
+                    <RevertIcon />
+                </IconButton>
                 <div
                     style={{
                         width: this.props.glContainer.width,

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,9 +5060,9 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.18.tgz",
-            "integrity": "sha512-7iUuTv416AdXFL8jgSxjIUfvm0U4jqcQI90/YnM+vgnIxH8Db8JRBMrjjLiu7MSN0wl7aS9kiuSXJjuI9ghXKg==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
                 "lodash": "4.17.4",

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "^0.6.18",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/src/RevenuePerYear.jsx
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/src/RevenuePerYear.jsx
@@ -43,7 +43,8 @@ class RevenuePerYear extends Widget {
                 legendTitleColor: "#5d6e77",
                 legendTextColor: "#5d6e77",
                 tickLabelColor: "#5d6e77",
-                axisLabelColor: "#5d6e77"
+                axisLabelColor: "#5d6e77",
+                legendTextSize: 14,
             },
             gridColor: "#5d6e77"
         };

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package-lock.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package-lock.json
@@ -5,9 +5,12 @@
     "requires": true,
     "dependencies": {
         "@wso2-dashboards/widget": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.0.tgz",
-            "integrity": "sha512-MtR8IGI03aQGS66eKXj3budSIqlSvas/ZH/xZV2L3rotcLamrqk8Xqu050FFkADoshsGuNevbGBaW3OqC2E2lg=="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.2.2.tgz",
+            "integrity": "sha512-j1sg6tgHonBcjeSh/DRD7nPdzEQOto18FBogbizzq2q+Y6uUx63+rqCvJl2rICQbJaxvsGLW1RrT3odDu7TZ0Q==",
+            "requires": {
+                "axios": "0.17.1"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -250,6 +253,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
             "dev": true
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "1.5.0",
+                "is-buffer": "1.1.6"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2441,6 +2453,24 @@
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+            "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+            "requires": {
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2968,8 +2998,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -3681,8 +3710,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.8.0",
@@ -5032,11 +5060,12 @@
             }
         },
         "react-vizgrammar": {
-            "version": "0.6.17",
-            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.6.17.tgz",
-            "integrity": "sha512-u3nnP1nC02kz1/U+AWtj1gZOh9eMk1arfm3/AJfJNzJUOCw0tMM6UljlduB28SWL3pNXshoyfC7ZyRbXLb7u+Q==",
+            "version": "0.7.14",
+            "resolved": "https://registry.npmjs.org/react-vizgrammar/-/react-vizgrammar-0.7.14.tgz",
+            "integrity": "sha512-NmzaX+/eOHbi8JRVGN6qEb4bKGw5nL0tzcesWNhCni84bR8BS7fBSHZaFOWpg9dHa2oCpV575/xxzzxA9dQIAw==",
             "requires": {
                 "d3": "4.12.0",
+                "lodash": "4.17.4",
                 "prop-types": "15.6.0",
                 "rc-slider": "8.5.0",
                 "react": "16.1.1",

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@wso2-dashboards/widget": "^1.2.0",
+        "@wso2-dashboards/widget": "^1.2.2",
         "d3": "^4.12.0",
         "material-ui": "^0.19.4",
         "prop-types": "^15.6.0",
@@ -13,7 +13,7 @@
         "react-simple-maps": "^0.9.0",
         "react-table": "^6.6.0",
         "react-tooltip": "^3.4.0",
-        "react-vizgrammar": "0.6.17",
+        "react-vizgrammar": "^0.7.14",
         "rimraf": "^2.6.2",
         "topojson-client": "^3.0.0",
         "victory": "^0.22.2"

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/src/RevenuePercentage.jsx
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/src/RevenuePercentage.jsx
@@ -26,13 +26,11 @@ class RevenuePercentage extends Widget {
         super(props);
         this.config = {
             charts: [{type: 'arc', x: 'Percentage', color: 'Percentage', colorScale: ['#c15832', '#dc8d48']}],
-            tooltip: {enabled: false},
-            legend: false,
             percentage: true,
             animate: true,
             labelColor:'#5d6e77',
-            width:this.props.glContainer.width,
-            height:this.props.glContainer.height
+            innerRadius: 20,
+            labelFontSize: 90,
         };
 
         this.state = {
@@ -91,8 +89,6 @@ class RevenuePercentage extends Widget {
                     data={this.state.data}
                     append={false}
                     onClick={this.handleClickEvent}
-                    height={this.props.glContainer.height}
-                    width={this.props.glContainer.width}
                 />
             </div>
         );


### PR DESCRIPTION
## Purpose
 - Bump versions of react-vizgrammar and base-widget in the dashboards and sample widgets
 - Style improvements for sample widgets

## Test environment
Node.JS v8.8.1, NPM v5.4.2