### PR TITLE
Remove unused step 'PubSub Configurations' in gadget-generation wizard UI

### DIFF
--- a/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
+++ b/components/dashboards-web-component/src/gadgets-generation-wizard/components/GadgetsGenerationWizard.jsx
@@ -560,13 +560,6 @@ class GadgetsGenerationWizard extends Component {
                                     <StepLabel
                                         style={this.getStepperTextStyle(stepIndex, 2)}
                                     >
-                                        PubSub Configurations
-                                    </StepLabel>
-                                </Step>
-                                <Step>
-                                    <StepLabel
-                                        style={this.getStepperTextStyle(stepIndex, 3)}
-                                    >
                                         Configure chart
                                     </StepLabel>
                                 </Step>


### PR DESCRIPTION
## Test environment
Node.JS v8.8.1, NPM v5.4.2