### PR TITLE
Revert "Publish default time range at first load"

### DIFF
--- a/samples/widgets/DateTimeRangePicker/src/DateRangePicker.jsx
+++ b/samples/widgets/DateTimeRangePicker/src/DateRangePicker.jsx
@@ -44,10 +44,8 @@ export default class DateRangePicker extends Widget {
             id: props.widgetID,
             width: props.glContainer.width,
             height: props.glContainer.height,
-            granularityMode: '1 Day',
-            granularityValue: 'hour',
-            startTime:Moment().subtract(1, 'days').toDate(),
-            endTime: new Date()
+            granularityMode: null,
+            granularityValue: '',
         };
 
         this.handleResize = this.handleResize.bind(this);
@@ -56,11 +54,7 @@ export default class DateRangePicker extends Widget {
         this.publishTimeRange = this.publishTimeRange.bind(this);
         this.getTimeIntervalDescriptor = this.getTimeIntervalDescriptor.bind(this);
         this.generateGranularitySelector = this.generateGranularitySelector.bind(this);
-        this.publishTimeRange({
-            granularity: 'hour',
-            from: this.state.startTime.getTime(),
-            to: this.state.endTime.getTime()
-        })
+
     }
 
     handleResize() {


### PR DESCRIPTION
## Purpose
This reverts commit 5c51b17ffb659c2bbc9c91a9a1e58658339c389b.
The above functionality ONLY works intermittently. For instance, If the subscriber widget loads later than the publisher, the initial published message is not reached and the state not updated.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes