### PR TITLE
Add box-sizing for UniversalWidget to add a gap between chart and container margin

### DIFF
--- a/components/universal-widget/src/UniversalWidget.jsx
+++ b/components/universal-widget/src/UniversalWidget.jsx
@@ -142,7 +142,7 @@ export default class UniversalWidget extends Widget {
 
     render() {
         return (
-            <div style={{width: this.props.glContainer.width, height: this.props.glContainer.height}}>
+            <div style={{ margin: 10, boxSizing: 'border-box' }}>
                 <VizG
                     config={this.state.config}
                     metadata={this.state.metadata}


### PR DESCRIPTION
## Test environment
Node.JS v8.8.1, NPM v5.4.2