### PR TITLE
Fix scroll bar always visible issue in Pages, Widgets panes in the designer

### DIFF
--- a/components/dashboards-web-component/src/designer/components/LeftSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/LeftSidePane.jsx
@@ -37,6 +37,9 @@ export default class LeftSidePane extends Component {
                     display: this.props.isHidden ? 'none' : 'block',
                 }}
             >
+                <div style={{ textAlign: 'center', paddingTop: 15, paddingBottom: 5, fontSize: 20, opacity: 0.5 }}>
+                    {this.props.title}
+                </div>
                 {this.props.children}
             </Drawer>
         );
@@ -44,6 +47,7 @@ export default class LeftSidePane extends Component {
 }
 
 LeftSidePane.propTypes = {
+    title: PropTypes.element.isRequired,
     children: PropTypes.element.isRequired,
     isHidden: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool.isRequired,

--- a/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
@@ -208,7 +208,7 @@ class PagesSidePane extends Component {
                     >
                         <FormattedMessage id="pages.config.title" defaultMessage="Pages" />
                     </div>
-                    <div style={{ height: '100%', overflowY: 'scroll' }}>
+                    <div style={{ height: '100%', overflowY: 'auto' }}>
                         <div style={{ paddingTop: 10 }}>
                             {pages.map(page => this.renderPageCard(page, landingPageId))}
                         </div>

--- a/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
@@ -196,20 +196,15 @@ class PagesSidePane extends Component {
                 {(this.getPageById(this.props.match.params.pageId) == null) ?
                     <Redirect to={this.getPageUrl(landingPageId)} /> :
                     null}
-                <LeftSidePane isHidden={this.props.isHidden} isOpen={this.props.isOpen} theme={this.props.theme}>
-                    <div style={{
-                        textAlign: 'center',
-                        paddingLeft: 12,
-                        paddingRight: 12,
-                        paddingTop: 15,
-                        fontSize: 20,
-                        opacity: 0.5,
-                    }}
-                    >
-                        <FormattedMessage id="pages.config.title" defaultMessage="Pages" />
-                    </div>
-                    <div style={{ height: '100%', overflowY: 'auto' }}>
-                        <div style={{ paddingTop: 10 }}>
+
+                <LeftSidePane
+                    isHidden={this.props.isHidden}
+                    isOpen={this.props.isOpen}
+                    theme={this.props.theme}
+                    title={<FormattedMessage id="pages.config.title" defaultMessage="Pages" />}
+                >
+                    <div style={{ height: '100%', overflowY: 'auto', overflowX: 'hidden' }}>
+                        <div>
                             {pages.map(page => this.renderPageCard(page, landingPageId))}
                         </div>
                         <div style={{ textAlign: 'center', paddingTop: 15 }}>

--- a/components/dashboards-web-component/src/designer/components/WidgetsSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetsSidePane.jsx
@@ -108,7 +108,7 @@ export default class WidgetsSidePane extends Component {
                                 />
                             </div>
                         </span>
-                        <div style={{ height: '100%', overflowY: 'scroll' }}>{this.widgets.map(
+                        <div style={{ height: '100%', overflowY: 'auto' }}>{this.widgets.map(
                             widget => this.renderWidgetCard(widget))}</div>
                     </span>
                 );

--- a/components/dashboards-web-component/src/designer/components/WidgetsSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetsSidePane.jsx
@@ -88,26 +88,13 @@ export default class WidgetsSidePane extends Component {
             } else {
                 innerContent = (
                     <span>
-                        <span>
-                            <div style={{
-                                textAlign: 'center',
-                                paddingLeft: 12,
-                                paddingRight: 12,
-                                paddingTop: 15,
-                                fontSize: 20,
-                                opacity: 0.5,
-                            }}
-                            >
-                                <FormattedMessage id="widgets.list.title" defaultMessage="Widgets" />
-                            </div>
-                            <div style={styles.message}>
-                                <TextField
-                                    hintText={<FormattedMessage id="search.hint.text" defaultMessage="Search widgets" />}
-                                    value={this.state.filter}
-                                    onChange={event => this.setState({ filter: event.target.value })}
-                                />
-                            </div>
-                        </span>
+                        <div style={styles.message}>
+                            <TextField
+                                hintText={<FormattedMessage id="search.hint.text" defaultMessage="Search widgets" />}
+                                value={this.state.filter}
+                                onChange={event => this.setState({ filter: event.target.value })}
+                            />
+                        </div>
                         <div style={{ height: '100%', overflowY: 'auto' }}>{this.widgets.map(
                             widget => this.renderWidgetCard(widget))}</div>
                     </span>
@@ -115,7 +102,12 @@ export default class WidgetsSidePane extends Component {
             }
         }
         return (
-            <LeftSidePane isHidden={this.props.isHidden} isOpen={this.props.isOpen} theme={this.props.theme}>
+            <LeftSidePane
+                isHidden={this.props.isHidden}
+                isOpen={this.props.isOpen}
+                theme={this.props.theme}
+                title={<FormattedMessage id="widgets.list.title" defaultMessage="Widgets" />}
+            >
                 {innerContent}
             </LeftSidePane>
         );

--- a/components/dashboards-web-component/src/designer/components/dashboard-container-styles.css
+++ b/components/dashboards-web-component/src/designer/components/dashboard-container-styles.css
@@ -19,7 +19,7 @@
 .dashboard-design-container {
     position: relative;
     width: calc(100% - 55px);
-    height: calc(100vh - 64px);
+    height: calc(100vh - 40px);
     max-height: 100vh;
     padding: 0;
     margin: 0 0 0 55px;

--- a/components/dashboards-web-component/src/designer/components/dashboard-container-styles.css
+++ b/components/dashboards-web-component/src/designer/components/dashboard-container-styles.css
@@ -18,8 +18,8 @@
 
 .dashboard-design-container {
     position: relative;
-    width: calc(100% - 55px);
-    height: calc(100vh - 40px);
+    width: calc(100% - 55px); /* 100vh - LeftSideActions.width */
+    height: calc(100vh - 40px); /* 100vh - theme.appBar.height */
     max-height: 100vh;
     padding: 0;
     margin: 0 0 0 55px;

--- a/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
@@ -40,8 +40,6 @@ import { darkTheme, lightTheme } from '../utils/Theme';
 
 const SelectableList = makeSelectable(List);
 
-const navIcon = { margin: 0, width: 'initial', height: 40, padding: 0 };
-
 class DashboardViewPage extends Component {
 
     constructor(props) {
@@ -146,10 +144,15 @@ class DashboardViewPage extends Component {
     }
 
     renderHeader(theme) {
+        const logo = (
+            <IconButton style={{ margin: 0, padding: 0, width: 'initial', height: theme.appBar.height }}>
+                <NavigationMenu />
+            </IconButton>
+        );
         return (
             <Header
                 title={this.dashboard ? this.dashboard.name : this.props.match.params.dashboardId}
-                logo={<IconButton style={navIcon}><NavigationMenu /></IconButton>}
+                logo={logo}
                 onLogoClick={this.handleSidePaneToggle}
                 rightElement={<span><PortalButton /><UserMenu /></span>}
                 theme={theme}

--- a/components/dashboards-web-component/src/viewer/components/dashboard-container-styles.css
+++ b/components/dashboards-web-component/src/viewer/components/dashboard-container-styles.css
@@ -19,7 +19,7 @@
 .dashboard-view-container {
     position: relative;
     width: 100%;
-    height: calc(100vh - 40px);
+    height: calc(100vh - 40px); /* 100vh - theme.appBar.height */
     max-height: 100vh;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
## Purpose
Fixes #974

## Goals
![image](https://user-images.githubusercontent.com/11549922/41529843-0e102a6c-730c-11e8-8102-ca4e2af1509e.png)

## Approach
Set `overflowY` to `auto` instead of `scroll`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
