### PR TITLE
Fix default roleId on creating dashboard

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/roles/provider/RolesProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/roles/provider/RolesProvider.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public class RolesProvider {
 
-    private static final String ROLE_ID = "admin";
+    private static final String ROLE_ID = "1";
 
     private List<String> creatorRoleIds = new ArrayList<>();
 


### PR DESCRIPTION
## Purpose
This PR fixes default `roleId` (for `admin` user) on creating a dashboard.