### PR TITLE
Fix GoldenLayout popover issue

### DIFF
--- a/components/dashboards-web-component/src/utils/GoldenLayoutOverrides.css
+++ b/components/dashboards-web-component/src/utils/GoldenLayoutOverrides.css
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ 
+/* Fixes popover issue in GoldenLayout (ex. autocomplete lists) */
+.lm_splitter {
+    z-index: initial;
+}
+
+.lm_header {
+    z-index: initial;
+}
+
+.lm_content {
+    overflow: initial;
+}
+

--- a/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
@@ -37,6 +37,7 @@ import Header from '../common/Header';
 import UserMenu from '../common/UserMenu';
 import PortalButton from '../common/PortalButton';
 import { darkTheme, lightTheme } from '../utils/Theme';
+import '../utils/GoldenLayoutOverrides.css';
 
 const SelectableList = makeSelectable(List);
 


### PR DESCRIPTION
## Purpose
In GoldenLayout, when the content is overflowing its container, the overflowing content is showing properly (ex: in an auto-complete list). This PR fixes that issue by resetting the related styles.