### PR TITLE
Fix listing page more options in Firefox

### DIFF
--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -50,6 +50,13 @@ const styles = {
         float: 'right',
         paddingRight: 0,
     },
+    moreButton: {
+        float: 'right',
+        padding: '4px'
+    },
+    cardTitle: {
+        float: 'left',
+    },
 };
 
 class DashboardCard extends Component {
@@ -221,10 +228,13 @@ class DashboardCard extends Component {
                     </CardMedia>
                     <CardTitle
                         actAsExpander={false}
-                        showExpandableButton={dashboard.hasOwnerPermission && dashboard.hasDesignerPermission}
-                        openIcon={<NavigationMoreVert onClick={this.handleMenuIconClick} />}
-                        closeIcon={<NavigationMoreVert onClick={this.handleMenuIconClick} />}
-                        title={title}
+                        showExpandableButton={false}
+                        title={
+                            <div>
+                                <span style={styles.cardTitle}>{title}</span>
+                                <NavigationMoreVert onClick={this.handleMenuIconClick} style={styles.moreButton} />
+                            </div>
+                        }
                         titleStyle={styles.cardTitleText}
                         subtitle={subtitle ? <span title={subtitle}>{subtitle}</span> : <span>&nbsp;</span>}
                         subtitleStyle={styles.cardSubtitleText}


### PR DESCRIPTION
## Purpose
In Firefox, "more options" for dashboards in dashboard listing page does not appear. Hence it is not possible to access the designer, setting pages and delete a dashboard.

This PR fixes that issue.
