### PR TITLE
Introduce a default date range

### DIFF
--- a/samples/widgets/DateTimeRangePicker/src/DateRangePicker.jsx
+++ b/samples/widgets/DateTimeRangePicker/src/DateRangePicker.jsx
@@ -46,6 +46,7 @@ export default class DateRangePicker extends Widget {
             height: props.glContainer.height,
             granularityMode: null,
             granularityValue: '',
+            options: this.props.configs.options,
         };
 
         this.handleResize = this.handleResize.bind(this);
@@ -119,6 +120,10 @@ export default class DateRangePicker extends Widget {
         }
 
         this.setState({ granularityMode: mode, granularityValue: granularity, startTime: startTime, endTime: new Date() });
+    }
+
+    componentDidMount() {
+        this.handleGranularityChange(this.state.options.defaultValue)
     }
 
     render() {

--- a/samples/widgets/DateTimeRangePicker/src/resources/widgetConf.json
+++ b/samples/widgets/DateTimeRangePicker/src/resources/widgetConf.json
@@ -12,6 +12,27 @@
                 "from",
                 "to"
             ]
-        }
+        },
+        "options": [
+            {
+                "id": "defaultValue",
+                "title": "Default Range",
+                "type": {
+                    "name": "ENUM",
+                    "possibleValues": [
+                        "1 Min",
+                        "15 Min",
+                        "1 Hour",
+                        "1 Day",
+                        "7 Days",
+                        "1 Month",
+                        "3 Months",
+                        "6 Months",
+                        "1 Year"
+                    ]
+                },
+                "defaultValue": "3 Months"
+            }
+        ]
     }
 }


### PR DESCRIPTION
## Purpose
Introduce a default date range for DateRangePicker widget.
Resolves: #986 

## Goals
Provide a default value

## Approach
Introduce a default value and make it configurable through the widget configuration panel.

