### PR TITLE
Add default theme for widgets in designer

### DIFF
--- a/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
@@ -297,6 +297,7 @@ export default class DashboardRenderer extends Component {
 
     render() {
         const renderingPage = this.getRenderingPage();
+        const { theme } = this.props;
         if (renderingPage) {
             return (
                 <div>
@@ -304,6 +305,11 @@ export default class DashboardRenderer extends Component {
                     <div
                         id={dashboardContainerId}
                         className='dashboard-design-container'
+                        style={{
+                            color: theme.palette.textColor,
+                            backgroundColor: theme.palette.canvasColor,
+                            fontFamily: theme.fontFamily,
+                        }}
                         ref={() => {
                             if (!this.unmounted) {
                                 this.renderGoldenLayout();


### PR DESCRIPTION
## Purpose
In the dashboard viewer, if a widget does not have styles defined the default theme will be applied. But in the dashboard designer, it is not. This PR applies default theme for widgets in the dashboard designer.

Resolves https://github.com/wso2/carbon-dashboards/issues/991