### PR TITLE
Add options to adjust height of dashboard pages.

### DIFF
--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -36,6 +36,7 @@
     "react-color": "^2.13.8",
     "react-dom": "^16.1.1",
     "react-intl": "^2.4.0",
+    "react-resizable": "^1.7.5",
     "react-router-dom": "^4.1.2",
     "react-shadow": "^2.0.2",
     "react-speed-dial": "^0.4.7",

--- a/components/dashboards-web-component/public/locales/en.json
+++ b/components/dashboards-web-component/public/locales/en.json
@@ -81,5 +81,8 @@
   "pages.config.title": "Pages",
   "widgets.list.title": "Widgets",
   "listing.loading": "Loading Dashboards...",
-  "designer.hide.page": "Hide Page"
+  "designer.hide.page": "Hide Page",
+  "page.height": "Height (px)",
+  "page.height.reset": "Reset height",
+  "page.height.overlay": "Height"
 }

--- a/components/dashboards-web-component/public/locales/fr.json
+++ b/components/dashboards-web-component/public/locales/fr.json
@@ -79,5 +79,8 @@
   "pages.config.title": "Pages",
   "widgets.list.title": "Widgets",
   "listing.loading": "Chargement des tableaux de bord...",
-  "designer.hide.page": "Masquer la page"
+  "designer.hide.page": "Masquer la page",
+  "page.height": "Hauteur (px)",
+  "page.height.reset": "Réinitialiser hauteur",
+  "page.height.overlay": "Hauteur"
 }

--- a/components/dashboards-web-component/src/designer/DashboardDesignerPage.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardDesignerPage.jsx
@@ -92,6 +92,20 @@ export default class DashboardDesignerPage extends Component {
         this.setState({ hasWidgetsLoaded: true });
     }
 
+    /**
+     * Update the dashboard when modified.
+     *
+     * @param {{*}} dashboard Dashboard object
+     */
+    dashboardUpdated(dashboard) {
+        this.dashboard = dashboard;
+    }
+
+    /**
+     * Render dashboard.
+     *
+     * @param {{*}} theme Theme
+     */
     renderDashboard(theme) {
         if (!this.state.hasWidgetsLoaded) {
             return (
@@ -104,15 +118,13 @@ export default class DashboardDesignerPage extends Component {
         }
 
         return (
-            <span>
-                <DashboardRenderer
-                    dashboard={this.dashboard}
-                    widgetsConfigurations={this.widgetsConfigurations}
-                    pageId={this.props.match.params.pageId}
-                    updateDashboard={this.handleDashboardUpdate}
-                    theme={theme}
-                />
-            </span>
+            <DashboardRenderer
+                dashboard={this.dashboard}
+                widgetsConfigurations={this.widgetsConfigurations}
+                pageId={this.props.match.params.pageId}
+                updateDashboard={this.handleDashboardUpdate}
+                theme={theme}
+            />
         );
     }
 
@@ -150,8 +162,21 @@ export default class DashboardDesignerPage extends Component {
                             dashboard={this.dashboard}
                             updateDashboard={this.handleDashboardUpdate}
                             setWidgetsConfigurations={this.handleSetWidgetsConfigurations}
+                            onDashboardUpdate={this.dashboardUpdated}
                         />
-                        {this.renderDashboard(defaultTheme)}
+                        <div
+                            style={{
+                                position: 'fixed',
+                                top: 40,
+                                right: 0,
+                                bottom: 0,
+                                left: 55,
+                                overflowX: 'hidden',
+                                overflowY: 'scroll',
+                            }}
+                        >
+                            {this.renderDashboard(defaultTheme)}
+                        </div>
                     </div>
                     <Snackbar
                         open={this.state.dashboardUpdateResultMessage != null}

--- a/components/dashboards-web-component/src/designer/components/LeftSideActions.jsx
+++ b/components/dashboards-web-component/src/designer/components/LeftSideActions.jsx
@@ -92,6 +92,7 @@ export default class LeftSideActions extends Component {
             theme,
             dashboard: this.props.dashboard,
             updateDashboard: this.props.updateDashboard,
+            onDashboardUpdate: this.props.onDashboardUpdate
         };
         const widgetsSidePaneProps = {
             theme,

--- a/components/dashboards-web-component/src/designer/components/PageCard.jsx
+++ b/components/dashboards-web-component/src/designer/components/PageCard.jsx
@@ -32,7 +32,7 @@ import {
     IconButton,
     TextField,
 } from 'material-ui';
-import { ActionDeleteForever } from 'material-ui/svg-icons';
+import { ActionDeleteForever, ActionCached } from 'material-ui/svg-icons';
 
 class PageCard extends Component {
     constructor(props) {
@@ -40,6 +40,7 @@ class PageCard extends Component {
         this.state = {
             title: props.page.name,
             url: props.page.id,
+            height: props.page.height || '',
             titleValidationErrorMessage: null,
             urlValidationErrorMessage: null,
             isDashboardDeleteConfirmDialogOpen: false,
@@ -50,6 +51,11 @@ class PageCard extends Component {
         this.handlePageUrlUpdate = this.handlePageUrlUpdate.bind(this);
         this.hideDashboardDeleteConfirmDialog = this.hideDashboardDeleteConfirmDialog.bind(this);
         this.showDashboardDeleteConfirmDialog = this.showDashboardDeleteConfirmDialog.bind(this);
+        this.handlePageHeightUpdate = this.handlePageHeightUpdate.bind(this);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({height: nextProps.page.height});
     }
 
     handleCardClick(expand) {
@@ -80,6 +86,28 @@ class PageCard extends Component {
         this.props.updatePageUrl(page.id, newPageUrl)
             .then(() => this.setState({ titleValidationErrorMessage: null }))
             .catch(errorMessage => this.setState({ url: page.id, urlValidationErrorMessage: errorMessage }));
+    }
+
+    /**
+     * Handle page height update.
+     *
+     * @param {boolean} reset Reset height to default size
+     */
+    handlePageHeightUpdate(reset) {
+        const page = this.props.page;
+        if (reset) {
+            // If reset option is set, reset the height to default i.e. empty.
+            this.state.height = '';
+            this.setState({height: ''});
+        }
+        if (page.height === this.state.height) {
+            // Page height did not change.
+            return;
+        }
+        if (this.props.updatePageHeight) {
+            // Update page height
+            this.props.updatePageHeight(page.id, this.state.height);
+        }
     }
 
     hideDashboardDeleteConfirmDialog() {
@@ -142,6 +170,24 @@ class PageCard extends Component {
                             onChange={event => this.setState({ url: event.target.value })}
                             onBlur={this.handlePageUrlUpdate}
                         />
+                        <div style={{position: 'relative'}}>
+                            <TextField
+                                fullWidth
+                                floatingLabelText={<FormattedMessage id="page.height" defaultMessage="Height (px)" />}
+                                value={this.state.height}
+                                onChange={e => this.setState({ height: e.target.value })}
+                                onBlur={() => this.handlePageHeightUpdate(false)}
+                                type="number"
+                            />
+                            <IconButton
+                                tooltip={<FormattedMessage id="page.height.reset" defaultMessage="Reset height" />}
+                                tooltipPosition="top-left"
+                                onClick={() => this.handlePageHeightUpdate(true)}
+                                style={{position: 'absolute', top: 18, right: 0}}
+                            >
+                                <ActionCached />
+                            </IconButton>
+                        </div>
                     </CardText>
                     <CardActions expandable style={{ display: 'flex' }}>
                         <div style={{ marginRight: 0, flexGrow: 2 }}>

--- a/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
@@ -44,6 +44,7 @@ class PagesSidePane extends Component {
         this.handlePageAdd = this.handlePageAdd.bind(this);
         this.handlePageDelete = this.handlePageDelete.bind(this);
         this.handlePageVisibility = this.handlePageVisibility.bind(this);
+        this.handlePageHeightUpdate = this.handlePageHeightUpdate.bind(this);
     }
 
     getPageById(pageId) {
@@ -200,6 +201,30 @@ class PagesSidePane extends Component {
     }
 
     /**
+     * Update page height.
+     *
+     * @param {string} pageId Page ID
+     * @param {number} height Page height
+     * @returns {Promise}
+     */
+    handlePageHeightUpdate(pageId, height) {
+        return new Promise((resolve, reject) => {
+            const page = this.getPageById(pageId);
+            const currentHeight = page.height;
+            page.height = height;
+            this.props.updateDashboard()
+                .then(() => {
+                    this.props.onDashboardUpdate(this.props.dashboard);
+                    resolve();
+                })
+                .catch(() => {
+                    page.height = currentHeight;
+                    reject();
+                });
+        });
+    }
+
+    /**
      * Render page entry in pages side panel.
      *
      * @param {{*}} page Page object
@@ -218,6 +243,7 @@ class PagesSidePane extends Component {
                     updateLandingPage={this.handleLandingPageUpdate}
                     deletePage={this.handlePageDelete}
                     updatePageVisibility={this.handlePageVisibility}
+                    updatePageHeight={this.handlePageHeightUpdate}
                 />
                 {page.pages ? page.pages.map(subPage => this.renderPageCard(subPage, landingPageId)) : null}
             </span>

--- a/components/dashboards-web-component/src/designer/components/dashboard-container-styles.css
+++ b/components/dashboards-web-component/src/designer/components/dashboard-container-styles.css
@@ -16,17 +16,6 @@
  * under the License.
  */
 
-.dashboard-design-container {
-    position: relative;
-    width: calc(100% - 55px); /* 100vh - LeftSideActions.width */
-    height: calc(100vh - 40px); /* 100vh - theme.appBar.height */
-    max-height: 100vh;
-    padding: 0;
-    margin: 0 0 0 55px;
-    border: 0;
-    overflow: hidden !important;
-}
-
 .lm_close {
     display: list-item !important;
     opacity: 0.6 !important;

--- a/components/dashboards-web-component/src/utils/GLResizable.css
+++ b/components/dashboards-web-component/src/utils/GLResizable.css
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.react-resizable {
+    position: relative;
+    margin-bottom: 50px;
+}
+
+.react-resizable-handle {
+    position: absolute;
+    height: 24px;
+    bottom: -25px;
+    right: 0;
+    left: 0;
+    background-image: linear-gradient(to bottom, transparent, transparent 11px, #386d86 11px, #386d86 13px, transparent 13px, transparent), url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAF96VFh0UmF3IHByb2ZpbGUgdHlwZSBBUFAxAAAImeNKT81LLcpMVigoyk/LzEnlUgADYxMuE0sTS6NEAwMDCwMIMDQwMDYEkkZAtjlUKNEABZiYm6UBoblZspkpiM8FAE+6FWgbLdiMAAABIUlEQVRIie2VMUvDUBSFz3kWXN2kgpOrZGiEugiZ9CeIYAKuLkk6dHGwiji41PwBBytI/4JToSIt2ILB1bXFzbUi77o0WCT2pVqc8m3v3nvOWe57D8iZJ7YXVGwvqMyiWchs7vo1RXVOcKdolTmMu625BYzNj5MzSSdriDFgww2OFNXp9zpJZ8XafB/Enftp+oIpQMA1CJ5+aK+a9DlGaLvhFYGSAG+jD737fBu9lvbDLaUQQaCSQSHuetf1KgDYXnhBwfaXC7TW8Ps39fb6nr+8WFBNAksC9FVKaM7/QtNAsgTpXXl4bFweTtMbbzIhLyQPUu0FTZPe+BYN4k67aJVJ0pmsa9EnvUZ09ucAABjG3dZkyNi8lkU7E7/5cHKMfALouViloM8HvQAAAABJRU5ErkJggg==");
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: ns-resize;
+}
+
+.react-resizable-handle:hover {
+    background-image: linear-gradient(to bottom, transparent, transparent 11px, #7cd5ff 11px, #7cd5ff 13px, transparent 13px, transparent), url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAF96VFh0UmF3IHByb2ZpbGUgdHlwZSBBUFAxAAAImeNKT81LLcpMVigoyk/LzEnlUgADYxMuE0sTS6NEAwMDCwMIMDQwMDYEkkZAtjlUKNEABZiYm6UBoblZspkpiM8FAE+6FWgbLdiMAAABIUlEQVRIie2VMUvDUBSFz3kWXN2kgpOrZGiEugiZ9CeIYAKuLkk6dHGwiji41PwBBytI/4JToSIt2ILB1bXFzbUi77o0WCT2pVqc8m3v3nvOWe57D8iZJ7YXVGwvqMyiWchs7vo1RXVOcKdolTmMu625BYzNj5MzSSdriDFgww2OFNXp9zpJZ8XafB/Enftp+oIpQMA1CJ5+aK+a9DlGaLvhFYGSAG+jD737fBu9lvbDLaUQQaCSQSHuetf1KgDYXnhBwfaXC7TW8Ps39fb6nr+8WFBNAksC9FVKaM7/QtNAsgTpXXl4bFweTtMbbzIhLyQPUu0FTZPe+BYN4k67aJVJ0pmsa9EnvUZ09ucAABjG3dZkyNi8lkU7E7/5cHKMfALouViloM8HvQAAAABJRU5ErkJggg==");
+}

--- a/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
@@ -139,7 +139,18 @@ class DashboardViewPage extends Component {
             <MuiThemeProvider muiTheme={currentTheme}>
                 {this.renderHeader(currentTheme)}
                 {this.renderSidePane(currentTheme)}
-                {this.renderDashboard(currentTheme)}
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: 40,
+                        right: 0,
+                        bottom: 0,
+                        left: 0,
+                        overflowY: 'scroll',
+                    }}
+                >
+                    {this.renderDashboard(currentTheme)}
+                </div>
             </MuiThemeProvider>
         );
     }
@@ -246,10 +257,8 @@ class DashboardViewPage extends Component {
     }
 
     renderDashboard(theme) {
-        const pageId = this.props.match.params.pageId,
-            subPageId = this.props.match.params.subPageId;
+        const { pageId, subPageId } = this.props.match.params;
         let page = this.dashboard.pages.find(page => (page.id === pageId));
-
         if (page) {
             if (page.pages && subPageId) {
                 page = page.pages.find(page => (page.id === subPageId));
@@ -258,6 +267,7 @@ class DashboardViewPage extends Component {
                 <DashboardRenderer
                     dashboardId={this.dashboard.url}
                     goldenLayoutContents={page.content}
+                    height={page.height}
                     theme={theme}
                 />
             );

--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -42,6 +42,9 @@ export default class DashboardRenderer extends Component {
         super(props);
         this.goldenLayout = null;
         this.loadedWidgetsCount = 0;
+        this.state = {
+            height: window.innerHeight
+        };
 
         this.handleWindowResize = this.handleWindowResize.bind(this);
         this.renderGoldenLayout = this.renderGoldenLayout.bind(this);
@@ -55,9 +58,11 @@ export default class DashboardRenderer extends Component {
         if (this.goldenLayout) {
             this.goldenLayout.updateSize();
         }
+        this.setState({height: window.innerHeight});
     }
 
     componentDidMount() {
+        this.setState({height: window.innerHeight});
         window.addEventListener('resize', this.handleWindowResize);
     }
 
@@ -72,6 +77,10 @@ export default class DashboardRenderer extends Component {
             // Receiving a new dashboard to render.
             this.destroyGoldenLayout();
             return true;
+        } else if (this.state.height !== nextState.height) {
+            // Dashboard resized.
+            this.destroyGoldenLayout();
+            return true;
         } else if (this.props.theme !== nextProps.theme) {
             // Receiving a new theme.
             this.triggerThemeChangeEvent(nextProps.theme);
@@ -81,24 +90,37 @@ export default class DashboardRenderer extends Component {
     }
 
     render() {
+        let { theme, height } = this.props;
+
+        // Calculate optimal dashboard height for the current screen.
+        const containerHeight = this.state.height - 55;
+        if (height) {
+            height = parseInt(height);
+        }
+        height = height && height > containerHeight ? height : containerHeight;
+
         return (
-            <span>
+            <div>
                 <style>{this.props.theme.name === 'dark' ? glDarkThemeCss : glLightThemeCss}</style>
                 <div
-                    id={dashboardContainerId}
-                    className='dashboard-view-container'
                     style={{
-                        color: this.props.theme.palette.textColor,
-                        backgroundColor: this.props.theme.palette.canvasColor,
-                        fontFamily: this.props.theme.fontFamily,
+                        color: theme.palette.textColor,
+                        backgroundColor: theme.palette.canvasColor,
+                        fontFamily: theme.fontFamily,
+                        height: height,
                     }}
-                    ref={() => {
-                        if (!this.unmounted) {
-                            this.renderGoldenLayout();
-                        }
-                    }}
-                />
-            </span>
+                >
+                    <div
+                        id={dashboardContainerId}
+                        className="dashboard-view-container"
+                        ref={() => {
+                            if (!this.unmounted) {
+                                this.renderGoldenLayout();
+                            }
+                        }}
+                    />
+                </div>
+            </div>
         );
     }
 

--- a/components/dashboards-web-component/src/viewer/components/dashboard-container-styles.css
+++ b/components/dashboards-web-component/src/viewer/components/dashboard-container-styles.css
@@ -19,10 +19,9 @@
 .dashboard-view-container {
     position: relative;
     width: 100%;
-    height: calc(100vh - 40px); /* 100vh - theme.appBar.height */
-    max-height: 100vh;
+    height: 100%;
     padding: 0;
     margin: 0;
     border: 0;
-    overflow: hidden !important;
 }
+


### PR DESCRIPTION
## Purpose
In dashboards, the dashboard page height cannot be modified, and it always takes 100% of the screen height. This PR introduces the ability to resize a page using page properties and resize handlers. 

Resolves https://github.com/wso2/product-sp/issues/702

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
