### PR TITLE
Add multi-select support in select fields in widget options

### DIFF
--- a/components/dashboards-web-component/src/designer/components/WidgetOptionsConfiguration.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetOptionsConfiguration.jsx
@@ -86,6 +86,7 @@ export default class WidgetOptionsConfiguration extends Component {
                                         this.handleWidgetOutput(options[i].id, payload, options[i].defaultValue);
                                     }}
                                     value={value}
+                                    multiple={!!options[i].type.multiple}
                                     id={options[i].id}
                                 >
                                     {items}


### PR DESCRIPTION
## Purpose
This PR add multiple selections in select fields (`ENUM` type) in widget options. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Refer the sample widget configuration fil below.

```json
{
    "name": "MultiSelect Sample",
    "id": "MultiSelectSample",
    "thumbnailURL": "",
    "configs": {
        "options": [
            {
                "id": "make",
                "title": "Make",
                "type": {
                  "name": "ENUM",
                  "multiple": true,
                  "possibleValues": [
                    "Toyota",
                    "Nissan",
                    "Honda",
                    "Hyundai",
                    "Isuzu",
                    "Mitsubishi"
                  ]
                },
                "defaultValue": ["Honda", "Isuzu"]
              }
        ]
    }
}
```