### PR TITLE
Introduce REST API to export a dashboard

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationIntercep
 import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
 import org.wso2.carbon.dashboards.core.DashboardMetadataProvider;
 import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
+import org.wso2.carbon.dashboards.core.bean.export.Dashboard;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
 import org.wso2.carbon.dashboards.core.exception.UnauthorizedException;
 import org.wso2.msf4j.Microservice;
@@ -41,6 +42,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -262,6 +264,34 @@ public class DashboardRestApi implements Microservice {
             return Response.serverError()
                     .entity("Cannot update user roles of dashboard '" + url + "'.")
                     .build();
+        }
+    }
+
+    /**
+     * Get dashboard with widget definitions.
+     * URL: https://localhost:9643/portal/apis/dashboards/<DASHBOARD_URL>/export
+     *
+     * To download the dashboard as an attachment,
+     * URL: https://localhost:9643/portal/apis/dashboards/<DASHBOARD_URL>/export?download=true
+     *
+     * @param url Dashboard URL
+     * @param download Flag to download as an attachment
+     * @return Dashboard JSON
+     */
+    @GET
+    @Path("/{url}/export")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response exportDashboard(@PathParam("url") String url, @QueryParam("download") boolean download) {
+        try {
+            Dashboard dashboard = dashboardDataProvider.exportDashboard(url);
+            Response.ResponseBuilder responseBuilder = Response.ok(dashboard);
+            if (download) {
+                responseBuilder.header("Content-Disposition", "attachment; filename=\"" + url + ".json\"");
+            }
+            return responseBuilder.build();
+        } catch (DashboardException e) {
+            LOGGER.error("Cannot export dashboard '" + replaceCRLFCharacters(url) + "'.", e);
+            return Response.serverError().entity("Cannot export dashboard '" + url + "'.").build();
         }
     }
 

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.dashboards.core;
 
 import org.wso2.carbon.analytics.permissions.bean.Role;
 import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
+import org.wso2.carbon.dashboards.core.bean.export.Dashboard;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
 
 import java.util.List;
@@ -62,4 +63,13 @@ public interface DashboardMetadataProvider {
 
     void updateDashboardRoles(String user, String dashboardUrl, Map<String, List<String>> roles) throws
             DashboardException;
+
+    /**
+     * Return exportable dashboard definition.
+     *
+     * @param dashboardUrl URL of the dashboard
+     * @return Exportable dashboard definition
+     * @throws DashboardException If an error occurred while reading or processing dashboards
+     */
+    Dashboard exportDashboard(String dashboardUrl) throws DashboardException;
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
@@ -59,6 +59,15 @@ public interface WidgetMetadataProvider {
     Set<WidgetMetaInfo> getAllWidgetConfigurations() throws DashboardException;
 
     /**
+     * Get configurations of given set of widgets.
+     *
+     * @param widgetIds Set of widget Ids
+     * @return Set of widget configurations
+     * @throws DashboardException If an error occurred when reading or processing configurations
+     */
+    Set<WidgetMetaInfo> getWidgetConfigurations(Set<String> widgetIds) throws DashboardException;
+
+    /**
      * Delete the configuration of the specified widget.
      *
      * @param widgetId id of the widget

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/Dashboard.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/Dashboard.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.bean.export;
+
+import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
+
+/**
+ * Bean class used represent a dashboard to export/import dashboards.
+ *
+ * @since 4.0.28
+ */
+public class Dashboard {
+    private DashboardMetadata dashboard;
+    private WidgetCollection widgets = new WidgetCollection();
+
+    public DashboardMetadata getDashboard() {
+        return dashboard;
+    }
+
+    public void setDashboard(DashboardMetadata dashboard) {
+        this.dashboard = dashboard;
+    }
+
+    public WidgetCollection getWidgets() {
+        return widgets;
+    }
+
+    public void setWidgets(WidgetCollection widgets) {
+        this.widgets = widgets;
+    }
+}
+

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/DashboardPage.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/DashboardPage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.bean.export;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Bean class to represent a dashboard page.
+ *
+ * @since 4.0.28
+ */
+public class DashboardPage {
+    private String id;
+    private String name;
+    private Set<DashboardPageContent> content = new HashSet<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<DashboardPageContent> getContent() {
+        return content;
+    }
+
+    public void setContent(Set<DashboardPageContent> content) {
+        this.content = content;
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/DashboardPageContent.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/DashboardPageContent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.bean.export;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Bean class to represent a dashboard page content.
+ *
+ * @since 4.0.28
+ */
+public class DashboardPageContent {
+    private String title;
+    private String type;
+    private String component;
+    private Set<DashboardPageContent> content = new HashSet<>();
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getComponent() {
+        return component;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public Set<DashboardPageContent> getContent() {
+        return content;
+    }
+
+    public void setContent(Set<DashboardPageContent> content) {
+        this.content = content;
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/WidgetCollection.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/export/WidgetCollection.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.bean.export;
+
+import org.wso2.carbon.dashboards.core.bean.widget.WidgetMetaInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Bean class to hold generated and custom widget definitions.
+ *
+ * @since 4.0.28
+ */
+public class WidgetCollection {
+    private Set<WidgetMetaInfo> generated = new HashSet<>();
+    private Set<String> custom = new HashSet<>();
+
+    public Set<WidgetMetaInfo> getGenerated() {
+        return generated;
+    }
+
+    public void setGenerated(Set<WidgetMetaInfo> generated) {
+        this.generated = generated;
+    }
+
+    public Set<String> getCustom() {
+        return custom;
+    }
+
+    public void setCustom(Set<String> custom) {
+        this.custom = custom;
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.dashboards.core.internal.io.WidgetConfigurationReader;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
 import org.wso2.carbon.uiserver.api.App;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -141,6 +142,36 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
                 widgetMetaInfo.setVersion(generatedWidgetConfigs.getVersion());
                 widgetMetaInfo.setConfigs(widgetConfigs);
                 widgetMetaInfoSet.add(widgetMetaInfo);
+            }
+        }
+        return widgetMetaInfoSet;
+    }
+
+    /**
+     * Get configurations of given set of widgets.
+     *
+     * @param widgetIds Set of widget Ids
+     * @return Set of widget configurations
+     * @throws DashboardException If an error occurred when reading or processing configurations
+     */
+    @Override
+    public Set<WidgetMetaInfo> getWidgetConfigurations(Set<String> widgetIds) throws DashboardException {
+        Set<WidgetMetaInfo> widgetMetaInfoSet = new HashSet<>();
+        if (isDaoInitialized) {
+            Set<GeneratedWidgetConfigs> generatedWidgetIdSet = widgetMetadataDao.getGeneratedWidgetIdSet();
+            for (GeneratedWidgetConfigs generatedWidgetConfigs: generatedWidgetIdSet) {
+                if (widgetIds.contains(generatedWidgetConfigs.getId())) {
+                    WidgetMetaInfo widgetMetaInfo = new WidgetMetaInfo();
+                    WidgetConfigs widgetConfigs = new WidgetConfigs();
+                    widgetMetaInfo.setId(generatedWidgetConfigs.getId());
+                    widgetMetaInfo.setName(generatedWidgetConfigs.getName());
+                    widgetConfigs.setPubsub(generatedWidgetConfigs.getPubsub());
+                    widgetConfigs.setMetadata(generatedWidgetConfigs.getMetadata());
+                    widgetConfigs.setGenerated(true);
+                    widgetMetaInfo.setVersion(generatedWidgetConfigs.getVersion());
+                    widgetMetaInfo.setConfigs(widgetConfigs);
+                    widgetMetaInfoSet.add(widgetMetaInfo);
+                }
             }
         }
         return widgetMetaInfoSet;


### PR DESCRIPTION
## Purpose
This PR introduces a REST API to export a dashboard.

To get the dashboard with widget definitions, use the following URL.
```
https://localhost:9643/portal/apis/dashboards/<DASHBOARD_URL>/export
```

To download the dashboard with widget definitions, use the following URL.
```
https://localhost:9643/portal/apis/dashboards/<DASHBOARD_URL>/export?download=true
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes