### PR TITLE
Bring theme switch to the header as a button

### DIFF
--- a/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
@@ -36,6 +36,7 @@ import DashboardRenderer from './components/DashboardRenderer';
 import Header from '../common/Header';
 import UserMenu from '../common/UserMenu';
 import PortalButton from '../common/PortalButton';
+import ThemeButton from './components/ThemeButton';
 import { darkTheme, lightTheme } from '../utils/Theme';
 import '../utils/GoldenLayoutOverrides.css';
 
@@ -45,7 +46,7 @@ class DashboardViewPage extends Component {
 
     constructor(props) {
         super(props);
-        let isDarkTheme = window.localStorage.getItem('isDarkTheme');
+        const isDarkTheme = window.localStorage.getItem('isDarkTheme');
         this.dashboard = null;
         this.isInitilialLoading = true;
         this.state = {
@@ -166,7 +167,16 @@ class DashboardViewPage extends Component {
                 title={this.dashboard ? this.dashboard.name : this.props.match.params.dashboardId}
                 logo={logo}
                 onLogoClick={this.handleSidePaneToggle}
-                rightElement={<span><PortalButton /><UserMenu /></span>}
+                rightElement = {
+                    <span style={{ position: 'relative' }}>
+                        <ThemeButton
+                            onThemeButtonClick={this.handleThemeToggle}
+                            theme={theme}
+                        />
+                        <PortalButton />
+                        <UserMenu />
+                    </span>
+                }
                 theme={theme}
             />
         );
@@ -189,21 +199,6 @@ class DashboardViewPage extends Component {
                 <SelectableList value={subPageId ? `${pageId}/${subPageId}` : pageId}>
                     {this.renderPagesList()}
                 </SelectableList>
-                <Divider />
-                <Subheader>
-                    <FormattedMessage id='theme.change-theme' defaultMessage='Theme' />
-                </Subheader>
-                <div style={{ display: 'flex', marginLeft: 72 }}>
-                    <span style={{ marginTop: 2, marginRight: 10 }}>
-                        <FormattedMessage id='theme.name.light' defaultMessage='Light' />
-                    </span>
-                    <Toggle
-                        toggled={this.state.isCurrentThemeDark}
-                        label={<FormattedMessage id='theme.name.dark' defaultMessage='Dark' />}
-                        labelPosition='right'
-                        onToggle={this.handleThemeToggle}
-                    />
-                </div>
             </Drawer>
         );
     }

--- a/components/dashboards-web-component/src/viewer/components/LightBulbFill.jsx
+++ b/components/dashboards-web-component/src/viewer/components/LightBulbFill.jsx
@@ -19,7 +19,7 @@
 import React, { Component } from 'react';
 import SvgIcon from 'material-ui/SvgIcon';
 
-class LightBulbFill extends Component {
+class LightBulbFillIcon extends Component {
     render() {
         return (
             <SvgIcon {...this.props}>
@@ -29,6 +29,6 @@ class LightBulbFill extends Component {
     }
 }
 
-LightBulbFill.muiName = 'SvgIcon';
+LightBulbFillIcon.muiName = 'SvgIcon';
 
-export default LightBulbFill;
+export default LightBulbFillIcon;

--- a/components/dashboards-web-component/src/viewer/components/LightBulbFill.jsx
+++ b/components/dashboards-web-component/src/viewer/components/LightBulbFill.jsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { Component } from 'react';
+import SvgIcon from 'material-ui/SvgIcon';
+
+class LightBulbFill extends Component {
+    render() {
+        return (
+            <SvgIcon {...this.props}>
+                <path d="M12,2A7,7 0 0,0 5,9C5,11.38 6.19,13.47 8,14.74V17A1,1 0 0,0 9,18H15A1,1 0 0,0 16,17V14.74C17.81,13.47 19,11.38 19,9A7,7 0 0,0 12,2M9,21A1,1 0 0,0 10,22H14A1,1 0 0,0 15,21V20H9V21Z" />
+            </SvgIcon>
+        );
+    }
+}
+
+LightBulbFill.muiName = 'SvgIcon';
+
+export default LightBulbFill;

--- a/components/dashboards-web-component/src/viewer/components/LightBulbOutline.jsx
+++ b/components/dashboards-web-component/src/viewer/components/LightBulbOutline.jsx
@@ -19,7 +19,7 @@
 import React, { Component } from 'react';
 import SvgIcon from 'material-ui/SvgIcon';
 
-class LightBulbOutline extends Component {
+class LightBulbOutlineIcon extends Component {
     render() {
         return (
             <SvgIcon {...this.props}>
@@ -29,6 +29,6 @@ class LightBulbOutline extends Component {
     }
 }
 
-LightBulbOutline.muiName = 'SvgIcon';
+LightBulbOutlineIcon.muiName = 'SvgIcon';
 
-export default LightBulbOutline;
+export default LightBulbOutlineIcon;

--- a/components/dashboards-web-component/src/viewer/components/LightBulbOutline.jsx
+++ b/components/dashboards-web-component/src/viewer/components/LightBulbOutline.jsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { Component } from 'react';
+import SvgIcon from 'material-ui/SvgIcon';
+
+class LightBulbOutline extends Component {
+    render() {
+        return (
+            <SvgIcon {...this.props}>
+                <path d="M12,2A7,7 0 0,1 19,9C19,11.38 17.81,13.47 16,14.74V17A1,1 0 0,1 15,18H9A1,1 0 0,1 8,17V14.74C6.19,13.47 5,11.38 5,9A7,7 0 0,1 12,2M9,21V20H15V21A1,1 0 0,1 14,22H10A1,1 0 0,1 9,21M12,4A5,5 0 0,0 7,9C7,11.05 8.23,12.81 10,13.58V16H14V13.58C15.77,12.81 17,11.05 17,9A5,5 0 0,0 12,4Z" />
+            </SvgIcon>
+        );
+    }
+}
+
+LightBulbOutline.muiName = 'SvgIcon';
+
+export default LightBulbOutline;

--- a/components/dashboards-web-component/src/viewer/components/ThemeButton.jsx
+++ b/components/dashboards-web-component/src/viewer/components/ThemeButton.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import { IconButton } from 'material-ui';
+
+import LightBulbFill from './LightBulbFill'
+import LightBulbOutline from './LightBulbOutline';
+
+class ThemeButton extends Component {
+    render() {
+        return (
+            <IconButton
+                style={{ color: '#fff', position: 'absolute', left: -40, }}
+                onClick={this.props.onThemeButtonClick}
+                title="Toggle Light/Dark theme"
+            >
+                {this.props.theme.name === 'dark' ? <LightBulbFill /> : <LightBulbOutline />}
+            </IconButton>
+        );
+    }
+}
+
+ThemeButton.propTypes = {
+    theme: PropTypes.shape({}).isRequired,
+    onThemeButtonClick: PropTypes.func.isRequired,
+};
+
+export default withRouter(ThemeButton);

--- a/components/dashboards-web-component/src/viewer/components/ThemeButton.jsx
+++ b/components/dashboards-web-component/src/viewer/components/ThemeButton.jsx
@@ -22,8 +22,8 @@ import PropTypes from 'prop-types';
 
 import { IconButton } from 'material-ui';
 
-import LightBulbFill from './LightBulbFill'
-import LightBulbOutline from './LightBulbOutline';
+import LightBulbFillIcon from './LightBulbFill'
+import LightBulbOutlineIcon from './LightBulbOutline';
 
 class ThemeButton extends Component {
     render() {
@@ -33,7 +33,7 @@ class ThemeButton extends Component {
                 onClick={this.props.onThemeButtonClick}
                 title="Toggle Light/Dark theme"
             >
-                {this.props.theme.name === 'dark' ? <LightBulbFill /> : <LightBulbOutline />}
+                {this.props.theme.name === 'dark' ? <LightBulbFillIcon /> : <LightBulbOutlineIcon />}
             </IconButton>
         );
     }


### PR DESCRIPTION
## Purpose
Bring theme switch to the header as a button to improve userbility.

![image](https://user-images.githubusercontent.com/20179540/44133242-689f4e20-a07c-11e8-942f-d075ebdfe75d.png)

fixes : #1012 