### PR TITLE
Report generation feature

### DIFF
--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -26,6 +26,8 @@
     "brace": "^0.11.0",
     "golden-layout": "^1.5.9",
     "html2canvas": "^1.0.0-alpha.12",
+    "jspdf": "^1.4.1",
+    "jspdf-autotable": "^2.3.4",
     "lodash": "^4.17.5",
     "material-ui": "^0.20.0",
     "material-ui-icons": "^1.0.0-beta.36",

--- a/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
@@ -22,9 +22,12 @@ import { Redirect, withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import _ from 'lodash';
 
-import { Divider, Drawer, IconButton, List, ListItem, makeSelectable, Subheader, Toggle } from 'material-ui';
+import { Divider, Drawer, IconButton, List, ListItem, makeSelectable, Subheader, Toggle, Checkbox, CardText, CardHeader,
+         CardActions ,RaisedButton, SelectField, MenuItem, Card, FlatButton, Dialog, CircularProgress } from 'material-ui';
 import { MuiThemeProvider } from 'material-ui/styles';
-import { ActionHome, NavigationMenu } from 'material-ui/svg-icons';
+import { ActionHome, NavigationMenu, ImagePictureAsPdf } from 'material-ui/svg-icons';
+
+import DeleteIcon from 'material-ui/svg-icons/action/delete';
 
 import DashboardAPI from '../utils/apis/DashboardAPI';
 import Error403 from '../error-pages/Error403';
@@ -39,6 +42,11 @@ import PortalButton from '../common/PortalButton';
 import { darkTheme, lightTheme } from '../utils/Theme';
 import '../utils/GoldenLayoutOverrides.css';
 
+import jspdf from 'jspdf';
+import html2cavas from 'html2canvas';
+import axios from 'axios';
+import { pdfConfig } from './components/JspdfConf.js';
+
 const SelectableList = makeSelectable(List);
 
 class DashboardViewPage extends Component {
@@ -52,6 +60,17 @@ class DashboardViewPage extends Component {
             dashboardFetchStatus: HttpStatus.UNKNOWN,
             isSidePaneOpen: true,
             isCurrentThemeDark: isDarkTheme ? isDarkTheme === 'true' : true,
+            printEnabledList: [],
+            pageList: [],
+            isPrintChecked: false,
+            pageSize: "A4",
+            resizeRatio: 1,
+            canvasWidth: 0,
+            canvasHeight: 0,
+            expanded: false,
+            reportStatusOpen: false,
+            completed: 0,
+            dialogOpen: false,
         };
 
         this.fetchDashboard = this.fetchDashboard.bind(this);
@@ -62,6 +81,15 @@ class DashboardViewPage extends Component {
         this.renderSidePane = this.renderSidePane.bind(this);
         this.renderPagesList = this.renderPagesList.bind(this);
         this.renderDashboard = this.renderDashboard.bind(this);
+
+        this.handleChange = this.handleChange.bind(this);
+        this.capturePage = this.capturePage.bind(this);
+        this.generatePdf = this.generatePdf.bind(this);
+        this.handleCardClick = this.handleCardClick.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.handleOpen = this.handleOpen.bind(this);
+        this.handleincludeGenerateTime = this.handleincludeGenerateTime.bind(this);
+        this.removePage = this.removePage.bind(this);
     }
 
     componentDidMount() {
@@ -104,6 +132,31 @@ class DashboardViewPage extends Component {
         };
     }
 
+    handleClose() {
+        this.setState({ dialogOpen: false });
+    }
+
+    handleOpen() {
+        this.setState({ dialogOpen: true });
+    }
+
+    handleincludeGenerateTime() {
+        this.setState({ includeTime: !this.state.includeTime });
+    }
+
+    handleReportStatusClose() {
+        this.setState({ reportStatusOpen: false });
+    }
+
+    handleReportStatusOpen() {
+        this.setState({ reportStatusOpen: true });
+    }
+
+    progress = () => {
+        const { completed } = this.state;
+        this.setState({ completed: completed >= 100 ? 0 : completed + 10 });
+    };
+
     render() {
         const currentTheme = this.state.isCurrentThemeDark ? darkTheme : lightTheme;
 
@@ -117,7 +170,7 @@ class DashboardViewPage extends Component {
             case HttpStatus.UNKNOWN:
                 // Still fetching the dashboard.
                 return (
-                    <MuiThemeProvider muiTheme={currentTheme}>
+                    <MuiThemeProvider theme={currentTheme}>
                         {this.renderHeader(currentTheme)}
                         <PageLoadingIndicator />
                     </MuiThemeProvider>
@@ -135,14 +188,61 @@ class DashboardViewPage extends Component {
             setTimeout(() => this.handleSidePaneToggle(), 1000);
         }
 
+        const dialogActions = [
+            <FlatButton
+                label="Cancel"
+                primary={true}
+                onClick={this.handleClose}
+            />,
+            <FlatButton
+                label="Export"
+                primary={true}
+                onClick={this.generatePdf}
+            />,
+        ];
+
+        const customStatusDailogStyle = {
+            width: 400,
+            maxWidth: 'none',
+            position: 'relative'
+        };
+
         return (
             <MuiThemeProvider muiTheme={currentTheme}>
                 {this.renderHeader(currentTheme)}
                 {this.renderSidePane(currentTheme)}
                 {this.renderDashboard(currentTheme)}
+
+                <Dialog
+                    title="Select PDF options"
+                    actions={dialogActions}
+                    modal={true}
+                    open={this.state.dialogOpen}
+                >
+                    <Checkbox
+                        label='Include report genetation time'
+                        onClick={this.handleincludeGenerateTime}
+                    />
+                </Dialog>
+
+                <Dialog
+                    title="Report is generating"
+                    contentStyle={customStatusDailogStyle}
+                    modal={true}
+                    open={this.state.reportStatusOpen}
+                >
+                    <CircularProgress
+                        mode="determinate"
+                        value={this.state.completed}
+                        size={80}
+                        thickness={5}
+                        style={{ marginLeft: '25%' }}
+                    />
+                </Dialog>
             </MuiThemeProvider>
         );
     }
+
 
     renderHeader(theme) {
         const logo = (
@@ -151,50 +251,318 @@ class DashboardViewPage extends Component {
             </IconButton>
         );
         return (
-            <Header
-                title={this.dashboard ? this.dashboard.name : this.props.match.params.dashboardId}
-                logo={logo}
-                onLogoClick={this.handleSidePaneToggle}
-                rightElement={<span><PortalButton /><UserMenu /></span>}
-                theme={theme}
-            />
+            <div data-html2canvas-ignore={true}>
+                <Header
+                    title={this.dashboard ? this.dashboard.name : this.props.match.params.dashboardId}
+                    logo={logo}
+                    onLogoClick={this.handleSidePaneToggle}
+                    rightElement={<span><PortalButton /><UserMenu /></span>}
+                    theme={theme}
+                />
+            </div>
         );
+    }
+
+    handleCardClick(expand) {
+        this.setState({ expanded: expand });
+
     }
 
     renderSidePane(theme) {
         const pageId = this.props.match.params.pageId,
             subPageId = this.props.match.params.subPageId;
+
+        const pageSizes = ["A4", "Letter", "Government-Letter"];
+
         return (
-            <Drawer
-                docked={false}
-                open={this.state.isSidePaneOpen}
-                onRequestChange={isOpen => this.setState({ isSidePaneOpen: isOpen })}
-                containerStyle={{ top: theme.appBar.height }}
-                overlayStyle={{ opacity: 0 }}
-            >
-                <Subheader>
-                    <FormattedMessage id='side-pane.pages' defaultMessage='Pages' />
-                </Subheader>
-                <SelectableList value={subPageId ? `${pageId}/${subPageId}` : pageId}>
-                    {this.renderPagesList()}
-                </SelectableList>
-                <Divider />
-                <Subheader>
-                    <FormattedMessage id='theme.change-theme' defaultMessage='Theme' />
-                </Subheader>
-                <div style={{ display: 'flex', marginLeft: 72 }}>
-                    <span style={{ marginTop: 2, marginRight: 10 }}>
-                        <FormattedMessage id='theme.name.light' defaultMessage='Light' />
+            <div data-html2canvas-ignore={true}>
+                <Drawer
+                    docked={false}
+                    open={this.state.isSidePaneOpen}
+                    onRequestChange={isOpen => this.setState({ isSidePaneOpen: isOpen })}
+                    containerStyle={{ top: theme.appBar.height }}
+                    overlayStyle={{ opacity: 0 }}
+
+                    id="hideFromPDF"
+                >
+                    <Subheader>
+                        <FormattedMessage id='side-pane.pages' defaultMessage='Pages' />
+                    </Subheader>
+                    <SelectableList value={subPageId ? `${pageId}/${subPageId}` : pageId}>
+                        {this.renderPagesList()}
+                    </SelectableList>
+                    <Divider />
+                    <Subheader>
+                        <FormattedMessage id='theme.change-theme' defaultMessage='Theme' />
+                    </Subheader>
+                    <div style={{ display: 'flex', marginLeft: 72 }}>
+                        <span style={{ marginTop: 2, marginRight: 10 }}>
+                            <FormattedMessage id='theme.name.light' defaultMessage='Light' />
+                        </span>
+                        <Toggle
+                            toggled={this.state.isCurrentThemeDark}
+                            label={<FormattedMessage id='theme.name.dark' defaultMessage='Dark' />}
+                            labelPosition='right'
+                            onToggle={this.handleThemeToggle}
+                        />
+
+                    </div>
+                    <br />
+                    <Divider />
+                    <span>
+                        <Card
+                            style={{ margin: 10 }}
+                            expanded={this.state.expanded}
+                            onExpandChange={this.handleCardClick}
+                        >
+                            <CardHeader title='Export dashboard' actAsExpander style={{ paddingRight: '0px' }} />
+                            <CardActions expandable style={{ display: 'flex', paddingRight: '0px' }}>
+                                <div style={{ marginRight: 0 }}>
+
+
+                                    <RaisedButton label='Capture current page'
+                                        onClick={this.capturePage}
+                                        primary />
+
+                                    <List>
+                                        {this.state.pageList.map(field =>
+                                            <ListItem primaryText={
+                                                            this.dashboard.pages.find(page => page.id === field).name}
+                                            rightIcon={<DeleteIcon />}
+                                                      onClick={() => this.removePage(field)} />
+                                        )}
+                                    </List>
+
+                                    <SelectField
+                                        style={{ width: 200 }}
+                                        floatingLabelText='Page Size'
+                                        value={this.state.pageSize}
+                                        onChange={(event, index, value) => { this.setState({ pageSize: value }) }}
+
+                                    >
+                                        {pageSizes.map(field =>
+                                            (
+                                                <MenuItem
+                                                    key={field}
+                                                    value={field}
+                                                    primaryText={field}
+                                                />
+                                            ))}
+                                    </SelectField>
+
+                                    <RaisedButton label='Export'
+                                        onClick={this.handleOpen}
+                                        disabled={!(this.state.pageList.length > 0)}
+                                        primary />
+                                </div>
+                            </CardActions>
+                        </Card>
                     </span>
-                    <Toggle
-                        toggled={this.state.isCurrentThemeDark}
-                        label={<FormattedMessage id='theme.name.dark' defaultMessage='Dark' />}
-                        labelPosition='right'
-                        onToggle={this.handleThemeToggle}
-                    />
-                </div>
-            </Drawer>
+                </Drawer>
+            </div>
         );
+    }
+
+    formatDate(date) {
+        let hours = date.getHours();
+        let minutes = date.getMinutes();
+        const ampm = hours >= 12 ? 'PM' : 'AM';
+        let day = date.getDate();
+        let month = date.getMonth() + 1;
+        hours = hours % 12;
+        hours = hours ? hours : 12; // the hour '0' should be '12'
+        minutes = minutes < 10 ? '0' + minutes : minutes;
+        day = day < 10 ? '0' + day : day;
+        month = month < 10 ? '0' + month : month;
+        const timeStr = hours + ':' + minutes + ' ' + ampm;
+        return day + "/" + month + "/" + date.getFullYear() + "  " + timeStr;
+    }
+
+    sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    async generatePdf() {
+
+        //Starts showing report generation progress
+        this.handleClose();
+        this.handleReportStatusOpen();
+        this.timer = setInterval(this.progress, 195);
+
+        let pdf = new jspdf("l", "px", this.state.pageSize.toLowerCase());
+
+        const title = document.getElementsByTagName("h1")[0].innerText;
+
+        // Get header : a cutomized header defined by the user or else the default stream processor header
+        await this.addPdfImage("/portal/apis/dashboards/pdfHeader", function (res) {
+            if (res != 'none') {
+                localStorage.setItem("dashboardHeader", res);
+            }
+        });
+
+        // Get footer : a cutomized footer defined by the user or else the no footer by default
+        await this.addPdfImage("/portal/apis/dashboards/pdfFooter", function (res) {
+            if (res != 'none') {
+                localStorage.setItem("dashboardFooter", res);
+            }
+        });
+
+        // To handle the async calls (wait until the image data is stored in localStorage)
+        await this.sleep(2000);
+
+        const img = localStorage.getItem("dashboardHeader");
+        pdf.addImage(img, "JPEG", pdfConfig.stampImageDashboard.coordinates.x,
+                     pdfConfig.stampImageDashboard.coordinates.y, pdfConfig.stampImageDashboard.size.x,
+                     pdfConfig.stampImageDashboard.size.y);
+
+        this.state.pageList.map((item, ind) => {
+            const it = localStorage.getItem(item);
+            const image = JSON.parse(it);
+            const imgData = image.imageData;
+
+            const imgWidth = image.width;
+            const imgHeight = image.height;
+
+            const page = this.dashboard.pages.find(page => {
+                return page.id == item;
+            })
+
+            //Add title
+            pdf.setFontSize(15);
+            pdf.setFontType('bold');
+            const padding = Array.apply(null, Array(title.length + 4)).map(function () { return "  " })
+            pdf.text((pdf.internal.pageSize.getHeight() / 2 + 30), 18, title + " : ");
+
+            const ntext = padding.join("") + page.name;
+            pdf.setFontType('normal');
+            pdf.text((pdf.internal.pageSize.getHeight() / 2 + 30), 18, ntext);
+
+            let pdfInfo = "";
+
+            if (this.state.includeTime) {
+                pdfInfo = "Generated on : " + this.formatDate(new Date());
+            }
+
+            pdf.setFontType('bold');
+            pdf.setFontSize(12);
+            pdf.text(pdfInfo, pdfConfig.stampImageDashboard.coordinates.x, 35);
+            pdf.setFontType('normal');
+
+            if (imgWidth > imgHeight) {
+                const val = (pdf.internal.pageSize.getWidth()) / imgWidth;
+
+                if (imgHeight * val < (pdf.internal.pageSize.getHeight())) {
+                    pdf.addImage(imgData, 'JPEG', 0, 55, imgWidth * val, imgHeight * val, "dashboard" + ind, "FAST");
+                } else {
+                    const valH = (pdf.internal.pageSize.getHeight()) / imgHeight;
+                    pdf.addImage(imgData, 'JPEG', 0, 55, imgWidth * valH, imgHeight * valH, "dashboard" + ind, "FAST");
+                }
+
+            } else {
+                const val = (pdf.internal.pageSize.getHeight()) / imgHeight;
+                pdf = new jspdf("p", "px", "a4");
+                pdf.addImage(imgData, 'JPEG', 0, 35, imgWidth * val, imgHeight * val, "dashboard" + ind, "FAST");
+            }
+
+            // FOOTER : a customized footer defined by the user in the deployment.yaml file or else no footer by default
+            const str = "Page " + (ind + 1) + " of " + this.state.pageList.length;
+            pdf.setFontSize(10);
+            const pageHeight = pdf.internal.pageSize.height || pdf.internal.pageSize.getHeight();
+            pdf.text(str, 10, pageHeight - 10);
+
+            const footerImg = localStorage.getItem('dashboardFooter');
+            if (footerImg != null) {
+                pdf.addImage(footerImg, "JPEG", 380, 780, pdfConfig.stampImage.size.x, pdfConfig.stampImage.size.y);
+            }
+
+            if (ind < this.state.pageList.length - 1) {
+                pdf.addPage();
+
+                // HEADER : a cutomized header defined by the user or else the default stream processor header
+                const headerImg = localStorage.getItem('dashboardHeader');
+                if (headerImg != null) {
+                    pdf.addImage(headerImg, "JPEG", pdfConfig.stampImageDashboard.coordinates.x,
+                                 pdfConfig.stampImageDashboard.coordinates.y, pdfConfig.stampImageDashboard.size.x,
+                                 pdfConfig.stampImageDashboard.size.y);
+                }
+            }
+        });
+
+        clearInterval(this.timer);
+        this.handleReportStatusClose();
+        this.state.completed = 0;
+        this.state.includeTime = false;
+
+        const docName = title + ".pdf";
+        pdf.save(docName);
+
+    }
+
+    // Get the image from deployment.yaml file through the server
+    async addPdfImage(url, callback) {
+        let path = "/portal/public/app/images/"
+
+        await axios.get(url, { auth: { username: "admin", password: "admin" } })
+            .then(function (res) {
+                if (res.data === '') {
+                    callback('none');
+                } else {
+                    path += res.data;
+
+                    //Convert image to bdase64 encoded image (data_url)
+                    const canvas = document.createElement('canvas');
+                    const ctx = canvas.getContext('2d');
+                    const img = new Image();
+                    let imgStr;
+
+                    img.onload = function () {
+                        canvas.width = img.width;
+                        canvas.height = img.height;
+                        ctx.drawImage(img, 0, 0);
+                        imgStr = canvas.toDataURL("image/png");
+                        callback(imgStr);
+                    }
+
+                    img.src = path;
+                }
+
+            });
+    }
+
+    async removePage(index) {
+
+        const newAr = this.state.pageList.slice();
+        const ind = newAr.indexOf(index);
+        newAr.splice(ind, 1);
+        this.setState({ pageList: newAr });
+
+        if (newAr.indexOf(index) == -1) {
+            localStorage.removeItem(index);
+        }
+
+    }
+
+    async capturePage(index) {
+
+        const url = window.location.href;
+        const parts = url.split('/');
+        const currentPage = parts[parts.length - 1] === "" ? parts[parts.length - 2] : parts[parts.length - 1];
+
+        await html2cavas(document.getElementById("content")).then((canvas) => {
+            const imgData = canvas.toDataURL('image/png');
+            const w = canvas.width;
+            const h = canvas.height;
+            localStorage.setItem(currentPage, JSON.stringify({ imageData: imgData, width: w, height: h }));
+
+            const newAr = this.state.pageList.slice();
+            newAr.push(currentPage);
+            this.setState({ pageList: newAr });
+
+            const val = 620 / canvas.width;
+            this.state.resizeRatio = val;
+            this.state.canvasWidth = canvas.width;
+            this.state.canvasHeight = canvas.height;
+        });
     }
 
     renderPagesList() {
@@ -227,6 +595,58 @@ class DashboardViewPage extends Component {
                     nestedItems={nestedItems}
                     open={!!nestedItems}
                     onClick={() => history.push(this.getNavigationToPage(page.id))}
+                />
+            );
+        });
+    }
+
+    handleChange(index) {
+        let newArray = this.state.printEnabledList.slice();
+
+        if (typeof newArray[index] != 'undefined') {
+            newArray[index].value = !newArray[index].value;
+            this.setState({ printEnabledList: newArray }, () => this.capturePage(index));
+        } else {
+            newArray[index] = { value: true };
+            this.setState({ printEnabledList: newArray }, () => this.capturePage(index));
+        }
+
+    }
+
+    renderPagesChecklist() {
+        const landingPage = this.dashboard.landingPage;
+
+        return this.dashboard.pages.map((page, index) => {
+            const isLandingPage = (page.id === landingPage);
+            let nestedItems = [];
+            if (page.pages) {
+                nestedItems = page.pages.map((subPage) => {
+                    const subPageId = `${page.id}/${subPage.id}`;
+                    return (
+                        <Checkbox
+                            key={subPageId}
+                            label={subPage.name}
+                            disabled={!(currentPage === page.id)}
+                            onClick={this.handleChange}
+                            checked={false}
+                        />
+                    );
+                });
+            }
+
+            //Gets the current page id from the URL
+            const url = window.location.href;
+            const parts = url.split('/');
+            const currentPage = parts[parts.length - 1] === "" ? parts[parts.length - 2] : parts[parts.length - 1];
+
+            return (
+                <Checkbox
+                    key={page.id}
+                    value={page.id}
+                    label={page.name}
+                    id={index}
+                    disabled={!((currentPage === page.id) || this.state.printEnabledList[index])}
+                    onClick={() => this.handleChange(index)}
                 />
             );
         });

--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -32,9 +32,19 @@ import '../../common/styles/custom-goldenlayout-light-theme.css';
 import glLightTheme from '!!css-loader!../../common/styles/custom-goldenlayout-light-theme.css';
 import './dashboard-container-styles.css';
 
+import jspdf from 'jspdf';
+import html2cavas from 'html2canvas';
+import { pdfConfig } from './JspdfConf.js';
+import axios from 'axios';
+
+import { Dialog, FlatButton, Checkbox, CircularProgress } from 'material-ui';
+
+import autoTable from 'jspdf-autotable';  //Need to work with report generation for tables (jspdf extension)
+
 const glDarkThemeCss = glDarkTheme.toString();
 const glLightThemeCss = glLightTheme.toString();
 const dashboardContainerId = 'dashboard-container';
+
 
 export default class DashboardRenderer extends Component {
 
@@ -48,7 +58,26 @@ export default class DashboardRenderer extends Component {
         this.destroyGoldenLayout = this.destroyGoldenLayout.bind(this);
         this.triggerThemeChangeEvent = this.triggerThemeChangeEvent.bind(this);
         this.onWidgetLoadedEvent = this.onWidgetLoadedEvent.bind(this);
+        this.onGoldenLayoutComponentAddEvent = this.onGoldenLayoutComponentAddEvent.bind(this);
         this.unmounted = false;
+
+        this.exportWidget = this.exportWidget.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.handleOpen = this.handleOpen.bind(this);
+        this.handleincludeGenerateTime = this.handleincludeGenerateTime.bind(this);
+        this.handleincludeNoOfRecords = this.handleincludeNoOfRecords.bind(this);
+
+        this.state = {
+            dialogOpen: false,
+            widget: null,
+            title: '',
+            includeTime: false,
+            includeRecords: false,
+            completed: 0,
+            reportStatusOpen: false,
+            recordCountEnabled: false,
+
+        };
     }
 
     handleWindowResize() {
@@ -58,6 +87,7 @@ export default class DashboardRenderer extends Component {
     }
 
     componentDidMount() {
+        this.setState({ height: window.innerHeight });
         window.addEventListener('resize', this.handleWindowResize);
     }
 
@@ -68,6 +98,7 @@ export default class DashboardRenderer extends Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
+
         if (this.props.goldenLayoutContents !== nextProps.goldenLayoutContents) {
             // Receiving a new dashboard to render.
             this.destroyGoldenLayout();
@@ -77,10 +108,370 @@ export default class DashboardRenderer extends Component {
             this.triggerThemeChangeEvent(nextProps.theme);
             return true;
         }
+
+        if (this.props.theme.name == 'light') {
+            this.triggerThemeChangeEvent(nextProps.theme);
+        }
+
+        if (this.state.dialogOpen != nextState.dialogOpen) {
+            return true;
+        }
+        if (this.state.reportStatusOpen != nextState.reportStatusOpen) {
+            return true;
+        }
+        if (this.state.completed < nextState.completed & nextState.completed <= 100) {
+            return true;
+        }
+        if (this.state.recordCountEnabled != nextState.recordCountEnabled) {
+            return true;
+        }
+
         return false;
     }
 
+    formatDate(date) {
+        let hours = date.getHours();
+        let minutes = date.getMinutes();
+        const ampm = hours >= 12 ? 'PM' : 'AM';
+        let day = date.getDate();
+        let month = date.getMonth() + 1;
+        hours = hours % 12;
+        hours = hours ? hours : 12; // the hour '0' should be '12'
+        minutes = minutes < 10 ? '0' + minutes : minutes;
+        day = day < 10 ? '0' + day : day;
+        month = month < 10 ? '0' + month : month;
+        const timeStr = hours + ':' + minutes + ' ' + ampm;
+        return day + "/" + month + "/" + date.getFullYear() + "  " + timeStr;
+    }
+
+    sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    async exportWidget() {
+        this.handleClose();
+        this.handleReportStatusOpen();
+        this.timer = setInterval(this.progress, 200);
+
+        const element = this.state.widget;
+        const docTitle = this.state.title;
+
+        //Initialize pdf object with margin parameters
+        const pdf = new jspdf("l", "mm", "a4");
+        const lMargin = 15;
+        const rMargin = 15;
+        const pdfInMM = 400;
+        const heightINMM = 600;
+        const pageCenter = pdfInMM / 2;
+
+        //Gets the document title from HTML and adds that in the center of the front page
+        //document and adds a border
+        const title = document.getElementsByTagName("h1")[0].innerText;
+        const mainTitle = title + " : ";
+
+        const lines = pdf.splitTextToSize(mainTitle, (pdfInMM - lMargin - rMargin));
+
+        if (element.innerHTML.search("rt-table") > -1) {
+            const colDivs = element.getElementsByClassName("rt-resizable-header-content");
+            const colData = [];
+            const colNum = colDivs.length;
+
+            for (let i = 0; i < colNum; i++) {
+                colData.push(colDivs[i].innerHTML);
+            }
+
+            let rowDivs;
+            if (this.props.theme.name == 'dark') {
+                rowDivs = element.getElementsByClassName("cell-data");
+            } else {
+                rowDivs = element.getElementsByTagName("span");
+            }
+
+            const rowNum = rowDivs.length / colDivs.length;
+            const rowData = [];
+
+            for (let i = 0; i < rowNum; i++) {
+                const row = [];
+                for (let j = 0; j < colNum; j++) {
+                    row.push(rowDivs[colNum * i + j].innerText)
+                }
+                rowData.push(row);
+            }
+
+            const doc = new jspdf('p', 'pt');
+            const totalPagesExp = "{total_pages_count_string}";
+
+            await this.addPdfImage("/portal/apis/dashboards/pdfHeader", function (res) {
+
+                localStorage.setItem("dashboardHeader", res);
+            });
+
+            await this.addPdfImage("/portal/apis/dashboards/pdfFooter", function (res) {
+                if (res != 'none') {
+
+                    localStorage.setItem("dashboardFooter", res);
+                }
+            });
+
+            await this.sleep(2000);
+
+            doc.setFontType('bold');
+            doc.text((pdf.internal.pageSize.getHeight() / 2 + 50), pdfConfig.title.coordinates.y - 30, mainTitle);
+            const offset = doc.getStringUnitWidth(mainTitle);
+            const padding = Array.apply(null, Array(mainTitle.length + 1)).map(function () { return " " })
+            doc.setFontType('normal');
+
+            const ntext = padding.join(" ") + docTitle;
+            doc.text((pdf.internal.pageSize.getHeight() / 2 + 50), pdfConfig.title.coordinates.y - 30, ntext);
+
+            let pdfInfo = "";
+
+            if (this.state.includeTime) {
+                pdfInfo += "Generated on : " + this.formatDate(new Date());
+            }
+
+            if (this.state.includeRecords) {
+                if (pdfInfo != '') {
+                    pdfInfo += "\n";
+                }
+                pdfInfo += "No of records : " + rowData.length;
+            }
+
+            doc.setFontType('bold');
+            doc.setFontSize(pdfConfig.text.size);
+            doc.text(pdfInfo, pdfConfig.text.coordinates.x, pdfConfig.text.coordinates.y - 20);
+            doc.setFontType('normal');
+
+            const pageContent = function (data) {
+                // HEADER
+                const headerImg = localStorage.getItem('dashboardHeader');
+                if (headerImg != null) {
+                    doc.addImage(headerImg, "JPEG", data.settings.margin.left,
+                                 pdfConfig.stampImageDashboard.coordinates.y, pdfConfig.stampImageDashboard.size.x,
+                                 pdfConfig.stampImageDashboard.size.y);
+                }
+
+                // FOOTER
+                let str = "Page " + data.pageCount;
+                // Total page number plugin only available in jspdf v1.0+
+                if (typeof doc.putTotalPages === 'function') {
+                    str = str + " of " + totalPagesExp;
+                }
+                doc.setFontSize(10);
+                const pageHeight = doc.internal.pageSize.height || doc.internal.pageSize.getHeight();
+                doc.text(str, data.settings.margin.left, pageHeight - 10);
+                const footerImg = localStorage.getItem('dashboardFooter');
+                if (footerImg != null) {
+                    doc.addImage(footerImg, "JPEG", 380, 780, pdfConfig.stampImage.size.x, pdfConfig.stampImage.size.y);
+                }
+
+            };
+
+            let tstyles = pdfConfig.pdfTableStyles;
+            tstyles.addPageContent = pageContent;
+            tstyles.margin = { top: 50, bottom: 50 };
+
+            doc.autoTable(colData, rowData, tstyles);
+
+            if (typeof doc.putTotalPages === 'function') {
+                doc.putTotalPages(totalPagesExp);
+            }
+
+            clearInterval(this.timer);
+            this.handleReportStatusClose();
+            this.state.completed = 0;
+            this.state.includeRecords = false;
+            this.state.includeTime = false;
+
+            const tableDocumentName = docTitle + ".pdf";
+            doc.save(tableDocumentName);
+
+
+        } else {
+            //Add the element's snapshot into the page
+            await this.addPdfImage("/portal/apis/dashboards/pdfHeader", function (res) {
+                pdf.addImage(res, "JPEG", pdfConfig.stampImageLandscape.coordinates.x,
+                             pdfConfig.stampImageLandscape.coordinates.y, pdfConfig.stampImageLandscape.size.x,
+                             pdfConfig.stampImageLandscape.size.y);
+            });
+
+            pdf.setFontType('bold');
+            pdf.text((pdf.internal.pageSize.getHeight() / 2 + 30), 12, mainTitle, null, null, 'center');
+            const offset = pdf.getStringUnitWidth(mainTitle) * 2.5;
+            const padding = Array.apply(null, Array(mainTitle.length + 1)).map(function () { return " " })
+            pdf.setFontType('normal');
+
+            const ntext = padding.join(" ") + docTitle;
+            pdf.text((pdf.internal.pageSize.getHeight() / 2 + 30) + offset, 12, ntext, null, null, 'center');
+
+            let pdfInfo = "";
+
+            if (this.state.includeTime) {
+                pdfInfo = "Generated on : " + this.formatDate(new Date());
+            }
+
+            pdf.setFontType('bold');
+            pdf.setFontSize(12);
+            pdf.text(pdfInfo, pdfConfig.stampImageLandscape.coordinates.x, 18);
+            pdf.setFontType('normal');
+
+            await this.addPdfImage("/portal/apis/dashboards/pdfFooter", function (res) {
+                if (res != 'none') {
+                    pdf.addImage(res, "JPEG", (pdf.internal.pageSize.getWidth() - 45),
+                                 (pdf.internal.pageSize.getHeight() - 8), pdfConfig.stampImageLandscape.size.x,
+                                 pdfConfig.stampImageLandscape.size.y);
+                }
+            });
+
+            await this.sleep(2000);
+
+            await html2cavas(element).then((canvas) => {
+                const imgData = canvas.toDataURL('image/png');
+                if (canvas.width > canvas.height - 28) {
+                    const val = (pdf.internal.pageSize.getWidth()) / canvas.width;
+                    const xposition = (pdf.internal.pageSize.getWidth() - canvas.width * val) / 2;
+
+                    if (canvas.height * val < 210) {
+                        if (canvas.height * val < 180) {
+                            pdf.addImage(imgData, 'JPEG', xposition, 45, canvas.width * val, canvas.height * val,
+                                                                                                "widget", "FAST");
+                        } else {
+                            pdf.addImage(imgData, 'JPEG', xposition, 25, canvas.width * val, canvas.height * val,
+                                                                                                "widget", "FAST");
+                        }
+                    } else {
+                        const valH = (pdf.internal.pageSize.getHeight() - 28) / canvas.height;
+                        const xposition = (pdf.internal.pageSize.getWidth() - canvas.width * valH) / 2;
+                        pdf.addImage(imgData, 'JPEG', xposition, 25, canvas.width * valH, canvas.height * valH,
+                                                                                                "widget", "FAST");
+                    }
+                } else {
+                    const val = (pdf.internal.pageSize.getHeight() - 28) / canvas.height;
+                    const xposition = (pdf.internal.pageSize.getWidth() - canvas.width * val) / 2;
+                    pdf == new jspdf("p", "mm", "a4");
+                    pdf.addImage(imgData, 'JPEG', xposition, 25, canvas.width * val, canvas.height * val,
+                                                                                                 "widget", "FAST");
+                }
+            });
+
+            clearInterval(this.timer);
+            this.handleReportStatusClose();
+            this.state.completed = 0;
+            this.state.includeRecords = false;
+            this.state.includeTime = false;
+
+            const documentName = docTitle + ".pdf";
+            pdf.save(documentName);
+        }
+    }
+
+    async addPdfImage(url, callback) {
+        let path = "/portal/public/app/images/"
+
+        await axios.get(url, { auth: { username: "admin", password: "admin" } })
+            .then(function (res) {
+                if (res.data === '') {
+                    callback('none');
+                } else {
+                    path += res.data;
+                    const canvas = document.createElement('canvas');
+                    const ctx = canvas.getContext('2d');
+                    const img = new Image();
+                    let imgStr;
+
+                    img.onload = function () {
+                        canvas.width = img.width;
+                        canvas.height = img.height;
+                        ctx.drawImage(img, 0, 0);
+                        imgStr = canvas.toDataURL("image/png");
+                        callback(imgStr);
+                    }
+
+                    img.src = path;
+                }
+
+            });
+    }
+
+    onGoldenLayoutComponentAddEvent(component) {
+        if (!component.parent || !component.parent.header) {
+            return; // Added component is not a widget.
+        }
+
+        this.goldenLayout._dragSources.forEach((dragSource) => {
+            if (dragSource._itemConfig.props.id === component.config.props.id) {
+                dragSource._itemConfig.props.id = DashboardUtils.generateUuid();
+            }
+        });
+
+        const settingsButton = document.createElement('i');
+        settingsButton.title = 'settings';
+        settingsButton.className = 'fw fw-export widget-export-button';
+        settingsButton.addEventListener('click', () => {
+            const selectedElement = component.element[0];
+            if (selectedElement.innerHTML.search("rt-table") > -1) {
+                this.setState({ recordCountEnabled: true });
+            }else{
+                this.setState({ recordCountEnabled: false });
+            }
+            this.handleOpen();
+            this.state.widget = component.element[0];
+            this.state.title = component.config.title;
+        });
+
+        component.parent.header.controlsContainer.prepend(settingsButton);
+    }
+
+    handleClose() {
+        this.setState({ dialogOpen: false });
+    }
+
+    handleOpen() {
+        this.setState({ dialogOpen: true });
+    }
+
+    handleincludeGenerateTime() {
+        this.setState({ includeTime: !this.state.includeTime });
+    }
+
+    handleincludeNoOfRecords() {
+        this.setState({ includeRecords: !this.state.includeRecords });
+    }
+
+    handleReportStatusClose() {
+        this.setState({ reportStatusOpen: false });
+    }
+
+    handleReportStatusOpen() {
+        this.setState({ reportStatusOpen: true });
+    }
+
+    progress = () => {
+        const { completed } = this.state;
+        this.setState({ completed: completed >= 100 ? 0 : completed + 10 });
+    };
+
+
     render() {
+        const dialogActions = [
+            <FlatButton
+                label="Cancel"
+                primary={true}
+                onClick={this.handleClose}
+            />,
+            <FlatButton
+                label="Export"
+                primary={true}
+                onClick={this.exportWidget}
+            />,
+        ];
+
+        const customStatusDailogStyle = {
+            width: 400,
+            maxWidth: 'none',
+            position: 'relative'
+        };
+
         return (
             <span>
                 <style>{this.props.theme.name === 'dark' ? glDarkThemeCss : glLightThemeCss}</style>
@@ -98,7 +489,43 @@ export default class DashboardRenderer extends Component {
                         }
                     }}
                 />
+
+                <Dialog
+                    title="Select PDF options"
+                    actions={dialogActions}
+                    modal={true}
+                    open={this.state.dialogOpen}
+                >
+                    <Checkbox
+                        label='Include report genetation time'
+                        onClick={this.handleincludeGenerateTime}
+                    />
+
+                    {(this.state.recordCountEnabled) && (
+                        <Checkbox
+                            label='Include number of records'
+                            onClick={this.handleincludeNoOfRecords}
+                        />
+                    )}
+                </Dialog>
+
+                <Dialog
+                    title="Report is generating"
+                    contentStyle={customStatusDailogStyle}
+                    modal={true}
+                    open={this.state.reportStatusOpen}
+                >
+                    <CircularProgress
+                        mode="determinate"
+                        value={this.state.completed}
+                        size={80}
+                        thickness={5}
+                        style={{ marginLeft: '25%' }}
+                    />
+                </Dialog>
+
             </span>
+
         );
     }
 
@@ -127,10 +554,15 @@ export default class DashboardRenderer extends Component {
             },
             content: goldenLayoutContents,
         };
+
         const dashboardContainer = document.getElementById(dashboardContainerId);
         const goldenLayout = new GoldenLayout(config, dashboardContainer);
         const renderingWidgetClassNames = GoldenLayoutContentUtils.getReferredWidgetClassNames(goldenLayoutContents);
         renderingWidgetClassNames.forEach(widgetName => goldenLayout.registerComponent(widgetName, WidgetRenderer));
+
+        goldenLayout.on('itemDropped', this.onGoldenLayoutComponentAddEvent);
+        goldenLayout.on('componentCreated', this.onGoldenLayoutComponentAddEvent);
+
         goldenLayout.eventHub.on(Event.DASHBOARD_VIEW_WIDGET_LOADED,
             () => this.onWidgetLoadedEvent(renderingWidgetClassNames.length, this.props.dashboardId));
 

--- a/components/dashboards-web-component/src/viewer/components/JspdfConf.js
+++ b/components/dashboards-web-component/src/viewer/components/JspdfConf.js
@@ -1,0 +1,29 @@
+const pdfConfig = {
+  stampImage: { coordinates: { x: 40, y: 10 }, size: { x: 140, y: 21 } },
+  themeColorImage: { coordinates: { x: 540, y: 0 }, size: { x: 50, y: 60 } },
+  stampImageLandscape: { coordinates: { x: 10, y: 5 }, size: { x: 35, y: 6 } },
+  stampImageDashboard: {
+    coordinates: { x: 10, y: 5 },
+    size: { x: 105, y: 16.5 }
+  },
+  title: { size: 10, coordinates: { x: 295, y: 90 } },
+  LandscapeTitle: { size: 10, coordinates: { x: 45, y: 45 } },
+  text: { size: 8, coordinates: { x: 40, y: 110 } },
+
+  pdfTableStyles: {
+    startY: 110,
+    styles: {
+      fontSize: 6,
+      rowHeight: 15,
+      lineColor: [255, 255, 255],
+      lineWidth: 1,
+      overflow: "linebreak"
+    },
+    columnStyles: { "1": { columnWidth: "auto" } },
+    headerStyles: { fillColor: [201, 202, 197], textColor: [0, 0, 0] },
+    alternateRowStyles: { fillColor: [240, 236, 224] },
+    bodyStyles: { fillColor: [255, 255, 255] }
+  }
+};
+
+export { pdfConfig };

--- a/components/dashboards-web-component/src/viewer/components/dashboard-container-styles.css
+++ b/components/dashboards-web-component/src/viewer/components/dashboard-container-styles.css
@@ -26,3 +26,15 @@
     border: 0;
     overflow: hidden !important;
 }
+
+.widget-export-button {
+    float: left;
+    color: #929292;
+    margin-right: 5px;
+    cursor: pointer;
+    opacity: 0.6;
+}
+
+.widget-export-button:hover {
+    opacity: 1;
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
@@ -275,4 +275,47 @@ public class DashboardRestApi implements Microservice {
         }
         return str;
     }
+
+
+    /**
+     * Gets the header image for the pdf generated for dashboard
+     *
+     * @return response
+     */
+    @GET
+    @Path("/pdfHeader")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getPdfHeader(@Context Request request) {
+        try {
+            Object pdfHeader = dashboardDataProvider.getPdfHeader();
+            return Response.ok().entity(pdfHeader).build();
+        } catch (DashboardException e) {
+            LOGGER.error("Cannot retrieve header image for pdf '", e);
+            return Response.serverError()
+                    .entity("Cannot retrieve header image for pdf '")
+                    .build();
+        }
+    }
+
+    /**
+     * Gets the footer image for the pdf generated for dashboard
+     *
+     * @return response
+     */
+    @GET
+    @Path("/pdfFooter")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getPdfFooter(@Context Request request) {
+        try {
+            Object pdfFooter = dashboardDataProvider.getPdfFooter();
+            return Response.ok().entity(pdfFooter).build();
+        } catch (DashboardException e) {
+            LOGGER.error("Cannot retrieve footer image for pdf '", e);
+            return Response.serverError()
+                    .entity("Cannot retrieve footer image for pdf '")
+                    .build();
+        }
+    }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -402,5 +402,26 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
     protected void unsetIdP(IdPClient client) {
         this.identityClient = null;
     }
+    
+    public String getPdfHeader() {
+        try {
+            Object x = ((Map<String, Object>) configProvider.getConfigurationObject("wso2.status.dashboard"))
+                    .get("pdfHeader");
+            return x.toString();
+        } catch (ConfigurationException e) {
+            LOGGER.error("Error in getting the pdf header image", e);
+        }
+        return "";
+    }
 
+    public String getPdfFooter() {
+        try {
+            Object x = ((Map<String, Object>) configProvider.getConfigurationObject("wso2.status.dashboard"))
+                    .get("pdfFooter");
+            return x.toString();
+        } catch (ConfigurationException e) {
+            LOGGER.error("Error in getting the pdf header image", e);
+        }
+        return "";
+    }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -402,7 +402,7 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
     protected void unsetIdP(IdPClient client) {
         this.identityClient = null;
     }
-    
+
     public String getPdfHeader() {
         try {
             Object x = ((Map<String, Object>) configProvider.getConfigurationObject("wso2.status.dashboard"))


### PR DESCRIPTION
## Purpose
This PR introduces functionality to export the dashboard and its widgets as PDF files. The charts and the overall dashboard view are exported as images and the tables are exported in table format.

## Goals
To export the dashboard as PDF.
Export the widgets separately as PDF.

## Approach
The dashboard can be downloaded as a PDF. Preferred pages in the dashboard can be exported by 'capture current page' button in the side pane. Then the page size can be chosen. The selected pages can be exported as a single PDF file. If the user wishes to include the report generation time, it also can be included in the report. It is prompted once after the export button is pressed. If the user can  remove a page from the report also.

The widgets can be exported separately as PDF files. There also it is prompted to include the report generation time. The table chart type is exported in the table format and user can select the option to include the number of records in the report. Rest of the chart types are exported as snapshot images.

Please refer [1] for more details.

[1] [https://docs.google.com/document/d/13E73LuVD5kE511ue2Vfx1MhSPj4Ve15_JQh6SV2by_Q/edit?](url)