### PR TITLE
Add dashboard import funcationality

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
@@ -25,7 +25,7 @@ import org.wso2.carbon.analytics.msf4j.interceptor.common.AuthenticationIntercep
 import org.wso2.carbon.analytics.msf4j.interceptor.common.util.InterceptorConstants;
 import org.wso2.carbon.dashboards.core.DashboardMetadataProvider;
 import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
-import org.wso2.carbon.dashboards.core.bean.export.Dashboard;
+import org.wso2.carbon.dashboards.core.bean.importer.DashboardArtifact;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
 import org.wso2.carbon.dashboards.core.exception.UnauthorizedException;
 import org.wso2.msf4j.Microservice;
@@ -274,6 +274,8 @@ public class DashboardRestApi implements Microservice {
      * To download the dashboard as an attachment,
      * URL: https://localhost:9643/portal/apis/dashboards/<DASHBOARD_URL>/export?download=true
      *
+     * @since 4.0.29
+     *
      * @param url Dashboard URL
      * @param download Flag to download as an attachment
      * @return Dashboard JSON
@@ -282,11 +284,13 @@ public class DashboardRestApi implements Microservice {
     @Path("/{url}/export")
     @Produces(MediaType.APPLICATION_JSON)
     public Response exportDashboard(@PathParam("url") String url, @QueryParam("download") boolean download) {
+
         try {
-            Dashboard dashboard = dashboardDataProvider.exportDashboard(url);
-            Response.ResponseBuilder responseBuilder = Response.ok(dashboard);
+            DashboardArtifact artifact = dashboardDataProvider.exportDashboard(url);
+            Response.ResponseBuilder responseBuilder = Response.ok(artifact);
             if (download) {
-                responseBuilder.header("Content-Disposition", "attachment; filename=\"" + url + ".json\"");
+                responseBuilder.header("Content-Disposition", "attachment; filename=\""
+                        + replaceCRLFCharacters(url) + ".json\"");
             }
             return responseBuilder.build();
         } catch (DashboardException e) {

--- a/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/pom.xml
@@ -110,6 +110,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+
+        <!--Utils-->
+        <dependency>
+            <groupId>org.wso2.carbon.utils</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -146,6 +153,7 @@
             com.google.gson.*; version="${gson.version.range}",
             org.yaml.snakeyaml.*; version="${org.yaml.version.range}",
             javax.ws.rs.*; version="${javax.ws.rs.version.range}",
+            org.wso2.carbon.utils.*; version="${carbon.utils.version.range}",
         </import.package>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
     </properties>

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
@@ -19,7 +19,7 @@ package org.wso2.carbon.dashboards.core;
 
 import org.wso2.carbon.analytics.permissions.bean.Role;
 import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
-import org.wso2.carbon.dashboards.core.bean.export.Dashboard;
+import org.wso2.carbon.dashboards.core.bean.importer.DashboardArtifact;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
 
 import java.util.List;
@@ -48,8 +48,42 @@ public interface DashboardMetadataProvider {
 
     Set<DashboardMetadata> getAllByUser(String user) throws DashboardException;
 
+    /**
+     * Add dashboard without permission check.
+     *
+     * @since 4.0.29
+     *
+     * @param dashboardMetadata Dashboard metadata
+     * @throws DashboardException
+     */
+    void add(DashboardMetadata dashboardMetadata) throws DashboardException;
+
+    /**
+     * Add dashboard with permission check for the given user.
+     *
+     * @param user Username
+     * @param dashboardMetadata Dashboard metadata
+     * @throws DashboardException
+     */
     void add(String user, DashboardMetadata dashboardMetadata) throws DashboardException;
 
+    /**
+     * Update dashboard without permission check.
+     *
+     * @since 4.0.29
+     *
+     * @param dashboardMetadata Dashboard metadata
+     * @throws DashboardException
+     */
+    void update(DashboardMetadata dashboardMetadata) throws DashboardException;
+
+    /**
+     * Update dashboard with permission check for the given user.
+     *
+     * @param user Username
+     * @param dashboardMetadata Dashboard metadata
+     * @throws DashboardException
+     */
     void update(String user, DashboardMetadata dashboardMetadata) throws DashboardException;
 
     void delete(String user, String dashboardUrl) throws DashboardException;
@@ -67,9 +101,11 @@ public interface DashboardMetadataProvider {
     /**
      * Return exportable dashboard definition.
      *
+     * @since 4.0.29
+     *
      * @param dashboardUrl URL of the dashboard
      * @return Exportable dashboard definition
      * @throws DashboardException If an error occurred while reading or processing dashboards
      */
-    Dashboard exportDashboard(String dashboardUrl) throws DashboardException;
+    DashboardArtifact exportDashboard(String dashboardUrl) throws DashboardException;
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.dashboards.core;
 
+import org.wso2.carbon.dashboards.core.bean.importer.WidgetType;
 import org.wso2.carbon.dashboards.core.bean.widget.GeneratedWidgetConfigs;
 import org.wso2.carbon.dashboards.core.bean.widget.WidgetMetaInfo;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
@@ -61,11 +62,24 @@ public interface WidgetMetadataProvider {
     /**
      * Get configurations of given set of widgets.
      *
+     * @since 4.0.29
+     *
      * @param widgetIds Set of widget Ids
      * @return Set of widget configurations
      * @throws DashboardException If an error occurred when reading or processing configurations
      */
     Set<WidgetMetaInfo> getWidgetConfigurations(Set<String> widgetIds) throws DashboardException;
+
+    /**
+     * Get generated widget configurations.
+     *
+     * @since 4.0.29
+     *
+     * @param widgetIds List og widget Ids
+     * @return Set of widget configurations
+     * @throws DashboardException
+     */
+    Set<GeneratedWidgetConfigs> getGeneratedWidgetConfigs(Set<String> widgetIds) throws DashboardException;
 
     /**
      * Delete the configuration of the specified widget.
@@ -83,6 +97,17 @@ public interface WidgetMetadataProvider {
      */
     boolean isWidgetPresent(String widgetName) throws DashboardException;
 
+    /**
+     * Check if the given widget is present in the filesystem.
+     *
+     * @since 4.0.29
+     *
+     * @param widgetName Name fo the widget
+     * @param widgetType Type of the widget
+     * @return Status
+     * @throws DashboardException
+     */
+    boolean isWidgetPresent(String widgetName, WidgetType widgetType) throws DashboardException;
     /**
      * Sets the dashboard portal app to this provider.
      *

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/DashboardArtifact.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/DashboardArtifact.java
@@ -16,33 +16,52 @@
  * under the License.
  */
 
-package org.wso2.carbon.dashboards.core.bean.export;
+package org.wso2.carbon.dashboards.core.bean.importer;
 
 import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
 
 /**
- * Bean class used represent a dashboard to export/import dashboards.
+ * Defines a dashboard data format to import/export a dashboard.
  *
- * @since 4.0.28
+ * @since 4.0.29
  */
-public class Dashboard {
+public class DashboardArtifact {
     private DashboardMetadata dashboard;
     private WidgetCollection widgets = new WidgetCollection();
 
+    /**
+     * Returns dashboard metadata object.
+     *
+     * @return Dashboard metadata
+     */
     public DashboardMetadata getDashboard() {
         return dashboard;
     }
 
+    /**
+     * Set dashboard metadata object.
+     *
+     * @param dashboard Dashboard metadata
+     */
     public void setDashboard(DashboardMetadata dashboard) {
         this.dashboard = dashboard;
     }
 
+    /**
+     * Returns widgets.
+     *
+     * @return Set of widgets
+     */
     public WidgetCollection getWidgets() {
         return widgets;
     }
 
+    /**
+     * Set widgets.
+     *
+     * @param widgets Set of widgets
+     */
     public void setWidgets(WidgetCollection widgets) {
         this.widgets = widgets;
     }
 }
-

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/Page.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/Page.java
@@ -16,42 +16,72 @@
  * under the License.
  */
 
-package org.wso2.carbon.dashboards.core.bean.export;
+package org.wso2.carbon.dashboards.core.bean.importer;
 
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Bean class to represent a dashboard page.
+ * Defines a page in dashboard JSON format.
  *
- * @since 4.0.28
+ * @since 4.0.29
  */
-public class DashboardPage {
+public class Page {
     private String id;
     private String name;
-    private Set<DashboardPageContent> content = new HashSet<>();
+    private Set<PageContent> content = new HashSet<>();
 
+    /**
+     * Returns dashboard Id.
+     *
+     * @return Dashboard ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Set dashboard Id.
+     *
+     * @param id Dashboard ID
+     */
     public void setId(String id) {
         this.id = id;
     }
 
+    /**
+     * Returns name of the dashboard.
+     *
+     * @return Dashboard name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Set name of the dashboard.
+     *
+     * @param name Dashboard name
+     */
     public void setName(String name) {
         this.name = name;
     }
 
-    public Set<DashboardPageContent> getContent() {
+    /**
+     * Returns contents of the page.
+     *
+     * @return Set of contents
+     */
+    public Set<PageContent> getContent() {
         return content;
     }
 
-    public void setContent(Set<DashboardPageContent> content) {
+    /**
+     * Set contents of the dashboard.
+     *
+     * @param content Set of contents
+     */
+    public void setContent(Set<PageContent> content) {
         this.content = content;
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/PageContent.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/PageContent.java
@@ -16,51 +16,89 @@
  * under the License.
  */
 
-package org.wso2.carbon.dashboards.core.bean.export;
+package org.wso2.carbon.dashboards.core.bean.importer;
 
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Bean class to represent a dashboard page content.
+ * Defines major contents of a dashboard page.
  *
- * @since 4.0.28
+ * @since 4.0.29
  */
-public class DashboardPageContent {
+public class PageContent {
     private String title;
     private String type;
     private String component;
-    private Set<DashboardPageContent> content = new HashSet<>();
+    private Set<PageContent> content = new HashSet<>();
 
+    /**
+     * Returns widget title.
+     *
+     * @return Widget title
+     */
     public String getTitle() {
         return title;
     }
 
+    /**
+     * Ste title of the widget.
+     * @param title Widget title
+     */
     public void setTitle(String title) {
         this.title = title;
     }
 
+    /**
+     * Returns type of the widget.
+     *
+     * @return Type of the widget
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Set type of the widget.
+     * @param type Widget type
+     */
     public void setType(String type) {
         this.type = type;
     }
 
+    /**
+     * Returns related component for the widget.
+     *
+     * @return Component of the widget
+     */
     public String getComponent() {
         return component;
     }
 
+    /**
+     * Set component of the widget.
+     *
+     * @param component Component
+     */
     public void setComponent(String component) {
         this.component = component;
     }
 
-    public Set<DashboardPageContent> getContent() {
+    /**
+     * Returns nested content of the page.
+     *
+     * @return Nested content
+     */
+    public Set<PageContent> getContent() {
         return content;
     }
 
-    public void setContent(Set<DashboardPageContent> content) {
+    /**
+     * Set nested content of the page.
+     *
+     * @param content Page content
+     */
+    public void setContent(Set<PageContent> content) {
         this.content = content;
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/WidgetCollection.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/WidgetCollection.java
@@ -16,34 +16,53 @@
  * under the License.
  */
 
-package org.wso2.carbon.dashboards.core.bean.export;
+package org.wso2.carbon.dashboards.core.bean.importer;
 
-import org.wso2.carbon.dashboards.core.bean.widget.WidgetMetaInfo;
-
+import org.wso2.carbon.dashboards.core.bean.widget.GeneratedWidgetConfigs;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Bean class to hold generated and custom widget definitions.
+ * Organizes widgets based on their type.
  *
- * @since 4.0.28
+ * @since 4.0.29
  */
 public class WidgetCollection {
-    private Set<WidgetMetaInfo> generated = new HashSet<>();
+    private Set<GeneratedWidgetConfigs> generated = new HashSet<>();
     private Set<String> custom = new HashSet<>();
 
-    public Set<WidgetMetaInfo> getGenerated() {
+    /**
+     * Returns generated widgets.
+     *
+     * @return Set of generated widgets
+     */
+    public Set<GeneratedWidgetConfigs> getGenerated() {
         return generated;
     }
 
-    public void setGenerated(Set<WidgetMetaInfo> generated) {
+    /**
+     * Set set of generated widgets.
+     *
+     * @param generated Generated widgets
+     */
+    public void setGenerated(Set<GeneratedWidgetConfigs> generated) {
         this.generated = generated;
     }
 
+    /**
+     * Returns Ids of the custom widgets.
+     *
+     * @return Set of IDs of the custom widgets
+     */
     public Set<String> getCustom() {
         return custom;
     }
 
+    /**
+     * Set Ids of the custom widgets.
+     *
+     * @param custom Set of IDs of the custom widgets
+     */
     public void setCustom(Set<String> custom) {
         this.custom = custom;
     }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/WidgetType.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/WidgetType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.wso2.carbon.dashboards.core.bean.importer;
+
+/**
+ * Defines widget type enum values.
+ *
+ * @since 4.0.29
+ */
+public enum WidgetType {
+    ALL,
+    CUSTOM,
+    GENERATED
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/exception/DashboardDeploymentException.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/exception/DashboardDeploymentException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.exception;
+
+/**
+ * Indicates an exception occurred in dashboard deployment.
+ *
+ * @since 4.0.28
+ */
+public class DashboardDeploymentException extends Exception {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public DashboardDeploymentException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently
+     * be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public DashboardDeploymentException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public DashboardDeploymentException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public DashboardDeploymentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.internal;
+
+
+import com.google.gson.Gson;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.dashboards.core.DashboardMetadataProvider;
+import org.wso2.carbon.dashboards.core.WidgetMetadataProvider;
+import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
+import org.wso2.carbon.dashboards.core.bean.importer.DashboardArtifact;
+import org.wso2.carbon.dashboards.core.bean.importer.WidgetType;
+import org.wso2.carbon.dashboards.core.bean.widget.GeneratedWidgetConfigs;
+import org.wso2.carbon.dashboards.core.exception.DashboardDeploymentException;
+import org.wso2.carbon.dashboards.core.exception.DashboardException;
+import org.wso2.carbon.utils.Utils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+/**
+ * Dashboard importer component. This is used to import dashboards in {DASHBOARD_RUNTIME}/resources/dashboards directory
+ * when server starts.
+ *
+ * @since 4.2.8
+ */
+@Component(immediate = true)
+public class DashboardImporter {
+    private static final Logger log = LoggerFactory.getLogger(DashboardImporter.class);
+    private static final String ARTIFACT_EXTENSION = "json";
+    private DashboardMetadataProvider dashboardMetadataProvider;
+    private WidgetMetadataProvider widgetMetadataProvider;
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        log.info("Dashboard importer activated.");
+        importDashboards();
+    }
+
+    @Deactivate
+    protected void deactivate(BundleContext bundleContext) {
+        log.info("Dashboard importer deactivated.");
+    }
+
+    /**
+     * Import dashboard artifacts from {DASHBOARD_RUNTIME}/resources/dashboards directory.
+     */
+    private void importDashboards() {
+        Path resourcesDir = Utils.getRuntimePath().resolve(Paths.get("resources", "dashboards"));
+        File[] files = resourcesDir.toFile().listFiles(f -> ARTIFACT_EXTENSION.equals(getExtension(f.getName())));
+        if (files != null) {
+            for (File file : files) {
+                try {
+                    importDashboard(file);
+                } catch (DashboardDeploymentException e) {
+                    log.error(e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Import single dashboard artifact from the given file.
+     *
+     * @param file Dashboard artifact
+     * @throws DashboardDeploymentException
+     */
+    private void importDashboard(File file) throws DashboardDeploymentException {
+        InputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(file);
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream,
+                    Charset.forName("UTF-8")));
+            DashboardArtifact dashboardArtifact = new Gson().fromJson(bufferedReader, DashboardArtifact.class);
+            if (dashboardArtifact != null) {
+                DashboardMetadata dashboard = dashboardArtifact.getDashboard();
+
+                log.info("Deploying dashboard '" + dashboard.getName() + "'...");
+
+                // Save the dashboard.
+                if (dashboardMetadataProvider.get(dashboard.getUrl()).isPresent()) {
+                    dashboardMetadataProvider.update(dashboard);
+                } else {
+                    dashboardMetadataProvider.add(dashboard);
+                }
+
+                // Notify missing custom widgets.
+                for (String widgetId : dashboardArtifact.getWidgets().getCustom()) {
+                    if (!widgetMetadataProvider.isWidgetPresent(widgetId, WidgetType.ALL)) {
+                        log.info("Widget '" + widgetId + "' not found. Please copy the widget.");
+                    }
+                }
+
+                // Deploy generated widgets if not available.
+                for (GeneratedWidgetConfigs widgetConfigs : dashboardArtifact.getWidgets().getGenerated()) {
+                    if (!widgetMetadataProvider.isWidgetPresent(widgetConfigs.getId(), WidgetType.ALL)) {
+                        log.info("Deploying widget '" + widgetConfigs.getId() + "'...");
+                        widgetMetadataProvider.addGeneratedWidgetConfigs(widgetConfigs);
+                    } else {
+                        log.info("Widget '" + widgetConfigs.getId() + "' is already deployed, hence skipping.");
+                    }
+                }
+
+                // Rename the dashboard json to prevent future deployments.
+                if (!file.renameTo(new File(file.getPath() + ".deployed"))) {
+                    log.warn("Error while renaming the dashboard artifact. The artifact will re-import in the next " +
+                            "server startup");
+                }
+            }
+        } catch (DashboardException e) {
+            throw new DashboardDeploymentException("Cannot import the dashboard.", e);
+        } catch (FileNotFoundException e) {
+            throw new DashboardDeploymentException("Cannot find the dashboard file.", e);
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    throw new DashboardDeploymentException("Error while closing the dashboard artifact.", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get extension from the given file name.
+     *
+     * @param name Name of the file
+     * @return Extension
+     */
+    private String getExtension(String name) {
+        int pos = name.lastIndexOf('.');
+        if (pos > 0 && pos < name.length()) {
+            return name.toLowerCase(Locale.ROOT).substring(pos + 1);
+        }
+        return "";
+    }
+
+    @Reference(service = DashboardMetadataProvider.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetDashboardMetadataProvider")
+    protected void setDashboardMetadataProvider(DashboardMetadataProvider dashboardMetadataProvider) {
+        this.dashboardMetadataProvider = dashboardMetadataProvider;
+        log.debug("DashboardMetadataProvider '{}' registered.", dashboardMetadataProvider.getClass().getName());
+    }
+
+    protected void unsetDashboardMetadataProvider(DashboardMetadataProvider dashboardMetadataProvider) {
+        this.dashboardMetadataProvider = null;
+        log.debug("DashboardMetadataProvider '{}' registered.", dashboardMetadataProvider.getClass().getName());
+    }
+
+    @Reference(service = WidgetMetadataProvider.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetWidgetMetadataProvider")
+    protected void setWidgetMetadataProvider(WidgetMetadataProvider widgetMetadataProvider) {
+        this.widgetMetadataProvider = widgetMetadataProvider;
+        log.debug("WidgetMetadataProvider '{}' registered.", widgetMetadataProvider.getClass().getName());
+    }
+
+    protected void unsetWidgetMetadataProvider(WidgetMetadataProvider widgetMetadataProvider) {
+        this.widgetMetadataProvider = null;
+        log.debug("WidgetMetadataProvider '{}' registered.", widgetMetadataProvider.getClass().getName());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,20 @@
                 <version>${mockito.core.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- Carbon Utils -->
+            <dependency>
+                <groupId>org.wso2.carbon.utils</groupId>
+                <artifactId>org.wso2.carbon.utils</artifactId>
+                <version>${carbon.utils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.utils</groupId>
+                <artifactId>org.wso2.carbon.utils.feature</artifactId>
+                <version>${carbon.utils.version}</version>
+                <type>zip</type>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -402,7 +416,10 @@
         <carbon.config.version>2.0.3</carbon.config.version>
         <carbon.config.version.range>[2.0.3, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.8</carbon.securevault.version>
+
+        <!--Utils-->
         <carbon.utils.version>2.0.2</carbon.utils.version>
+        <carbon.utils.version.range>[2.0.2, 3.0.0)</carbon.utils.version.range>
 
         <!--UI Server-->
         <carbon.uiserver.version>0.19.5</carbon.uiserver.version>


### PR DESCRIPTION
## Purpose
In SP, there was no way to import dashboards other than copying the dashboard into the database. This PR introduces a dashboard importer so that dashboard JSONs resides at `<SP_HOME>/wso2/dashboards/resources/dashboards` are getting deployed upon the server startup. Dashboard JSONs can be generated via the export API.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
