### PR TITLE
Fix messages getting lost if publisher widget loaded before subscriber widget gets loaded

### DIFF
--- a/base-widget/package.json
+++ b/base-widget/package.json
@@ -23,7 +23,7 @@
     "babel-preset-react": "^6.24.1"
   },
   "bugs": {
-    "url": "https://github.com/npm/npm/issues"
+    "url": "https://github.com/wso2/carbon-dashboards/issues"
   },
   "dependencies": {
     "axios": "^0.17.1"

--- a/base-widget/src/Widget.jsx
+++ b/base-widget/src/Widget.jsx
@@ -58,10 +58,10 @@ export default class Widget extends Component {
         if (!publisherId) {
             const publisherIds = this.props.configs.pubsub.publishers;
             if (publisherIds && Array.isArray(publisherIds)) {
-                publisherIds.forEach(id => this.props.glEventHub.on(id, listenerCallback));
+                publisherIds.forEach(id => this.props.pubSubHub.subscribe(id, listenerCallback));
             }
         } else {
-            this.props.glEventHub.on(publisherId, listenerCallback, context);
+            this.props.pubSubHub.subscribe(publisherId, listenerCallback, context);
         }
     }
 
@@ -70,12 +70,7 @@ export default class Widget extends Component {
      * @param listnerCallback
      */
     publish(message) {
-        let publishedChannel = this.props.id;
-        if (!this.props.glContainer.layoutManager.isInitialised) {
-            this.messageQueue.push(message)
-        } else {
-            this.props.glEventHub.emit(publishedChannel, message);
-        }
+        this.props.pubSubHub.publish(this.props.id, message);
     }
 
     /**

--- a/base-widget/src/Widget.jsx
+++ b/base-widget/src/Widget.jsx
@@ -28,26 +28,12 @@ export default class Widget extends Component {
     constructor(props) {
         super(props);
 
-        this.messageQueue = [];
-        this.props.glContainer.layoutManager.on('initialised', this.publishQueuedMessages);
         this._getLocalState = this._getLocalState.bind(this);
         this._setLocalState = this._setLocalState.bind(this);
         this.getWidgetState = this.getWidgetState.bind(this);
         this.setWidgetState = this.setWidgetState.bind(this);
         this.subscribe = this.subscribe.bind(this);
-        this.publishQueuedMessages = this.publishQueuedMessages.bind(this);
         this.channelManager = props.channelManager;
-    }
-
-    /**
-     * This method publishers the queued messages in the widget. The messages are queued when the widget tried to
-     * publish before initializing the dashboard.
-     *
-     */
-    publishQueuedMessages() {
-        for (let messageId in this.messageQueue) {
-            this.publish(this.messageQueue[messageId])
-        }
     }
 
     /**

--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "NODE_ENV=test NODE_TLS_REJECT_UNAUTHORIZED='0' mocha --recursive --require babel-register  -r mock-local-storage \"./test/**/*.test.js\"",
     "clean": "rimraf dist",
-    "dev": "NODE_ENV=development webpack -d --progress",
+    "dev": "NODE_ENV=development webpack -d --progress --devtool source-map",
     "lint": "eslint . --ext .jsx --ext .js",
     "build": "webpack -p",
     "deploy": "cp ./dist/bundle.js $DS_HOME/wso2/dashboard/deployment/web-ui-apps/portal/public/js/"

--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -69,7 +69,7 @@ export default class WidgetRenderer extends Component {
         this.triggerEvent = this.triggerEvent.bind(this);
 
         props.glContainer.on('resize', this.handleResize);
-        props.glEventHub.on(Event.DASHBOARD_VIEW_THEME_CHANGE, this.handleThemeUpdate);
+        props.glEventHub.on(Event.DASHBOARD_VIEWER_THEME_CHANGE, this.handleThemeUpdate);
         props.glEventHub.on(Event.DASHBOARD_DESIGNER_WIDGET_CONFIG_UPDATE, this.handleWidgetConfigUpdate);
     }
 

--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -114,7 +114,7 @@ export default class WidgetRenderer extends Component {
                 window.eval(response.data);
                 if (this.getWidgetClass()) {
                     this.updateWidgetLoadingStatus(WidgetLoadingStatus.LOADED);
-                    this.triggerEvent(Event.DASHBOARD_VIEW_WIDGET_LOADED, this.widgetName);
+                    this.triggerEvent(Event.DASHBOARD_VIEWER_WIDGET_LOADED, this.widgetName);
                 } else {
                     this.updateWidgetLoadingStatus(WidgetLoadingStatus.FETCHING_FAIL);
                 }

--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -147,7 +147,7 @@ export default class WidgetRenderer extends Component {
     }
 
     triggerEvent(name, parameter) {
-        this.props.glContainer.layoutManager.eventHub.trigger(name, parameter);
+        this.props.glEventHub.trigger(name, parameter);
     }
 
     renderWidgetLoadingStatus(message, isErrorMessage = false) {

--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -224,6 +224,7 @@ export default class WidgetRenderer extends Component {
                     ...this.props,
                     width: this.props.glContainer.width,
                     height: this.props.glContainer.height,
+                    pubSubHub: this.props.glContainer.layoutManager.pubSubHub,
                     muiTheme: this.state.currentTheme,
                     channelManager: getWidgetChannelManager(),
                 };

--- a/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
@@ -21,9 +21,7 @@ import { FormattedMessage } from 'react-intl';
 import { Paper } from 'material-ui';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import GoldenLayout from 'golden-layout';
 import 'golden-layout/src/css/goldenlayout-base.css';
-import GoldenLayoutContentUtils from '../../utils/GoldenLayoutContentUtils';
 import WidgetRenderer from '../../common/WidgetRenderer';
 import { ResizableBox } from 'react-resizable';
 
@@ -34,6 +32,7 @@ import './dashboard-container-styles.css';
 import WidgetConfigurationPane from './WidgetConfigurationPane';
 import DashboardUtils from '../../utils/DashboardUtils';
 import { Event } from '../../utils/Constants';
+import GoldenLayoutFactory from '../../utils/GoldenLayoutFactory';
 import './../../utils/GLResizable.css';
 
 const glDarkThemeCss = glDarkTheme.toString();
@@ -258,30 +257,8 @@ export default class DashboardRenderer extends Component {
             return;
         }
 
-        const goldenLayoutContents = this.getRenderingPage().content || [];
-        const config = {
-            settings: {
-                constrainDragToContainer: false,
-                reorderEnabled: true,
-                selectionEnabled: false,
-                popoutWholeStack: false,
-                blockedPopoutsThrowError: true,
-                closePopoutsOnUnload: true,
-                responsiveMode: 'always',
-                hasHeaders: true,
-                showPopoutIcon: false,
-                showMaximiseIcon: false,
-                showCloseIcon: true,
-            },
-            dimensions: {
-                headerHeight: 25,
-            },
-            content: goldenLayoutContents,
-        };
-        const dashboardContainer = document.getElementById(dashboardContainerId);
-        const goldenLayout = new GoldenLayout(config, dashboardContainer);
-        const renderingWidgetClassNames = GoldenLayoutContentUtils.getReferredWidgetClassNames(goldenLayoutContents);
-        renderingWidgetClassNames.forEach(widgetName => goldenLayout.registerComponent(widgetName, WidgetRenderer));
+        const goldenLayoutContents = this.getRenderingPage().content;
+        const goldenLayout = GoldenLayoutFactory.createForDesigner(dashboardContainerId, goldenLayoutContents);
 
         goldenLayout.on('initialised', this.onGoldenLayoutInitializedEvent);
         goldenLayout.on('stackCreated', blockDropOnStack);
@@ -291,8 +268,7 @@ export default class DashboardRenderer extends Component {
         goldenLayout.on('itemDestroyed', this.hideWidgetConfigurationPane);
         goldenLayout.eventHub.on(Event.DASHBOARD_DESIGNER_WIDGET_RESIZE, this.updateDashboard);
 
-        // Workaround suggested in https://github.com/golden-layout/golden-layout/pull/348#issuecomment-350839014
-        setTimeout(() => goldenLayout.init(), 0);
+        goldenLayout.initialize();
         this.goldenLayout = goldenLayout;
     }
 

--- a/components/dashboards-web-component/src/utils/Constants.jsx
+++ b/components/dashboards-web-component/src/utils/Constants.jsx
@@ -40,11 +40,11 @@ const MediaType = {
 
 /**
  * Events.
- * @type {{DASHBOARD_VIEWER_THEME_CHANGE: string, DASHBOARD_VIEW_WIDGET_LOADED: string}}
+ * @type {{DASHBOARD_VIEWER_THEME_CHANGE: string, DASHBOARD_VIEWER_WIDGET_LOADED: string}}
  */
 const Event = {
     DASHBOARD_VIEWER_THEME_CHANGE: 'dashboard-viewer-theme-change',
-    DASHBOARD_VIEW_WIDGET_LOADED: 'dashboard-view-widget-loaded',
+    DASHBOARD_VIEWER_WIDGET_LOADED: 'dashboard-viewer-widget-loaded',
     DASHBOARD_DESIGNER_WIDGET_RESIZE: 'dashboard-designer-widget-resize',
     DASHBOARD_DESIGNER_WIDGET_CONFIG_UPDATE: 'dashboard-designer-widget-config-update',
 };

--- a/components/dashboards-web-component/src/utils/Constants.jsx
+++ b/components/dashboards-web-component/src/utils/Constants.jsx
@@ -40,10 +40,10 @@ const MediaType = {
 
 /**
  * Events.
- * @type {{DASHBOARD_VIEW_THEME_CHANGE: string, DASHBOARD_VIEW_WIDGET_LOADED: string}}
+ * @type {{DASHBOARD_VIEWER_THEME_CHANGE: string, DASHBOARD_VIEW_WIDGET_LOADED: string}}
  */
 const Event = {
-    DASHBOARD_VIEW_THEME_CHANGE: 'dashboard-view-theme-change',
+    DASHBOARD_VIEWER_THEME_CHANGE: 'dashboard-viewer-theme-change',
     DASHBOARD_VIEW_WIDGET_LOADED: 'dashboard-view-widget-loaded',
     DASHBOARD_DESIGNER_WIDGET_RESIZE: 'dashboard-designer-widget-resize',
     DASHBOARD_DESIGNER_WIDGET_CONFIG_UPDATE: 'dashboard-designer-widget-config-update',

--- a/components/dashboards-web-component/src/utils/GoldenLayoutFactory.js
+++ b/components/dashboards-web-component/src/utils/GoldenLayoutFactory.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import GoldenLayout from 'golden-layout';
+import WidgetRenderer from '../common/WidgetRenderer';
+import GoldenLayoutContentUtils from './GoldenLayoutContentUtils';
+import WidgetPubSubHub from './WidgetPubSubHub';
+
+export default class GoldenLayoutFactory {
+    /**
+     * Creates a GoldenLayout object for the given container with given configs.
+     * @param {string} dashboardContainerId container ID
+     * @param {{settings: object, dimensions: object, content: object}} glConfig config
+     * @returns {module:golden-layout.GoldenLayout} created GoldenLayout
+     */
+    static create(dashboardContainerId, glConfig) {
+        const dashboardContainer = document.getElementById(dashboardContainerId);
+        const goldenLayout = new GoldenLayout(glConfig, dashboardContainer);
+
+        const renderingWidgetClassNames = GoldenLayoutContentUtils.getReferredWidgetClassNames(glConfig.content);
+        renderingWidgetClassNames.forEach(widgetName => goldenLayout.registerComponent(widgetName, WidgetRenderer));
+
+        goldenLayout.pubSubHub = new WidgetPubSubHub(goldenLayout.eventHub);
+        goldenLayout.initialize = () => {
+            // Workaround suggested in https://github.com/golden-layout/golden-layout/pull/348#issuecomment-350839014
+            setTimeout(() => goldenLayout.init(), 0);
+        };
+
+        return goldenLayout;
+    }
+
+    /**
+     *
+     * @param dashboardContainerId
+     * @param glContent
+     * @returns {module:golden-layout.GoldenLayout}
+     */
+    static createForViewer(dashboardContainerId, glContent) {
+        const config = {
+            settings: {
+                constrainDragToContainer: false,
+                reorderEnabled: false,
+                selectionEnabled: false,
+                popoutWholeStack: false,
+                blockedPopoutsThrowError: true,
+                closePopoutsOnUnload: true,
+                responsiveMode: 'always',
+                hasHeaders: true,
+                showPopoutIcon: false,
+                showMaximiseIcon: true,
+                showCloseIcon: false,
+            },
+            dimensions: {
+                headerHeight: 25,
+            },
+            content: glContent || [],
+        };
+        return GoldenLayoutFactory.create(dashboardContainerId, config);
+    }
+
+    static createForDesigner(dashboardContainerId, glContent) {
+        const config = {
+            settings: {
+                constrainDragToContainer: false,
+                reorderEnabled: true,
+                selectionEnabled: false,
+                popoutWholeStack: false,
+                blockedPopoutsThrowError: true,
+                closePopoutsOnUnload: true,
+                responsiveMode: 'always',
+                hasHeaders: true,
+                showPopoutIcon: false,
+                showMaximiseIcon: false,
+                showCloseIcon: true,
+            },
+            dimensions: {
+                headerHeight: 25,
+            },
+            content: glContent || [],
+        };
+        return GoldenLayoutFactory.create(dashboardContainerId, config);
+    }
+}

--- a/components/dashboards-web-component/src/utils/GoldenLayoutFactory.js
+++ b/components/dashboards-web-component/src/utils/GoldenLayoutFactory.js
@@ -45,10 +45,10 @@ export default class GoldenLayoutFactory {
     }
 
     /**
-     *
-     * @param dashboardContainerId
-     * @param glContent
-     * @returns {module:golden-layout.GoldenLayout}
+     * Creates a GoldenLayout for the dashboard viewer.
+     * @param {string} dashboardContainerId container ID
+     * @param {object} glContent content
+     * @returns {module:golden-layout.GoldenLayout} created GoldenLayout
      */
     static createForViewer(dashboardContainerId, glContent) {
         const config = {
@@ -73,6 +73,12 @@ export default class GoldenLayoutFactory {
         return GoldenLayoutFactory.create(dashboardContainerId, config);
     }
 
+    /**
+     * Creates a GoldenLayout for the dashboard viewer.
+     * @param {string} dashboardContainerId container ID
+     * @param {object} glContent content
+     * @returns {module:golden-layout.GoldenLayout} created GoldenLayout
+     */
     static createForDesigner(dashboardContainerId, glContent) {
         const config = {
             settings: {

--- a/components/dashboards-web-component/src/utils/WidgetClassRegistry.js
+++ b/components/dashboards-web-component/src/utils/WidgetClassRegistry.js
@@ -80,8 +80,22 @@ function extendsFromDeprecatedWidgetClassVersion(widgetClass) {
  */
 function patchWidgetClass(widgetClass) {
     const superWidgetClassPrototype = Object.getPrototypeOf(widgetClass.prototype);
+    // TODO 2018/08/22: When the new version of base-widget published, replace following patching with prototype.
     // Patch subscribe method.
-    superWidgetClassPrototype.subscribe = Widget.prototype.subscribe;
+    superWidgetClassPrototype.subscribe = function (listenerCallback, publisherId, context) {
+        if (!publisherId) {
+            const publisherIds = this.props.configs.pubsub.publishers;
+            if (publisherIds && Array.isArray(publisherIds)) {
+                publisherIds.forEach(id => this.props.pubSubHub.subscribe(id, listenerCallback));
+            }
+        } else {
+            this.props.pubSubHub.subscribe(publisherId, listenerCallback, context);
+        }
+    };
+    // Patch publish method.
+    superWidgetClassPrototype.publish = function (message) {
+        this.props.pubSubHub.publish(this.props.id, message);
+    };
 }
 
 global.dashboard = {};

--- a/components/dashboards-web-component/src/utils/WidgetPubSubHub.js
+++ b/components/dashboards-web-component/src/utils/WidgetPubSubHub.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export default class WidgetPubSubHub {
+    constructor(glEventHub) {
+        this.glEventHub = glEventHub;
+        this.lastPublishedMessages = {};
+    }
+
+    /**
+     * Publishes a message to subscribers.
+     * @param {string} publisherId ID of the message publisher
+     * @param {object} message publishing message
+     */
+    publish(publisherId, message) {
+        this.lastPublishedMessages[publisherId] = message;
+        this.glEventHub.emit(publisherId, message);
+    }
+
+    /**
+     * Subscribes to messages.
+     * @param {string} publisherId ID of the message publisher that needs to listen to
+     * @param {function(message)} listenerCallback The listener function that should be invoked when a message received
+     * @param {object} [listenerThisContext] The value of the <code>this</code> pointer in the listener function
+     */
+    subscribe(publisherId, listenerCallback, listenerThisContext) {
+        const lastPublishedMessage = this.lastPublishedMessages[publisherId];
+        if (lastPublishedMessage) {
+            listenerCallback.call(listenerThisContext, lastPublishedMessage);
+        }
+        this.glEventHub.on(publisherId, listenerCallback, listenerThisContext);
+    }
+}

--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -153,7 +153,7 @@ export default class DashboardRenderer extends Component {
         const goldenLayout = new GoldenLayout(config, dashboardContainer);
         const renderingWidgetClassNames = GoldenLayoutContentUtils.getReferredWidgetClassNames(goldenLayoutContents);
         renderingWidgetClassNames.forEach(widgetName => goldenLayout.registerComponent(widgetName, WidgetRenderer));
-        goldenLayout.eventHub.on(Event.DASHBOARD_VIEW_WIDGET_LOADED,
+        goldenLayout.eventHub.on(Event.DASHBOARD_VIEWER_WIDGET_LOADED,
             () => this.onWidgetLoadedEvent(renderingWidgetClassNames.length, this.props.dashboardId));
 
         // Workaround suggested in https://github.com/golden-layout/golden-layout/pull/348#issuecomment-350839014
@@ -186,6 +186,6 @@ export default class DashboardRenderer extends Component {
 
 DashboardRenderer.propTypes = {
     dashboardId: PropTypes.string.isRequired,
-    goldenLayoutContents: PropTypes.array.isRequired,
+    goldenLayoutContents: PropTypes.arrayOf({}).isRequired,
     theme: PropTypes.shape({}).isRequired,
 };

--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -172,7 +172,7 @@ export default class DashboardRenderer extends Component {
 
     triggerThemeChangeEvent(newTheme) {
         if (this.goldenLayout) {
-            this.goldenLayout.eventHub.trigger(Event.DASHBOARD_VIEW_THEME_CHANGE, newTheme);
+            this.goldenLayout.eventHub.trigger(Event.DASHBOARD_VIEWER_THEME_CHANGE, newTheme);
         }
     }
 

--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -18,13 +18,12 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import GoldenLayout from 'golden-layout';
 import 'golden-layout/src/css/goldenlayout-base.css';
 
 import GoldenLayoutContentUtils from '../../utils/GoldenLayoutContentUtils';
-import WidgetRenderer from '../../common/WidgetRenderer';
 import DashboardThumbnail from '../../utils/DashboardThumbnail';
 import { Event } from '../../utils/Constants';
+import GoldenLayoutFactory from '../../utils/GoldenLayoutFactory';
 
 import '../../common/styles/custom-goldenlayout-dark-theme.css';
 import glDarkTheme from '!!css-loader!../../common/styles/custom-goldenlayout-dark-theme.css';
@@ -129,35 +128,14 @@ export default class DashboardRenderer extends Component {
             return;
         }
 
-        const goldenLayoutContents = this.props.goldenLayoutContents || [];
-        const config = {
-            settings: {
-                constrainDragToContainer: false,
-                reorderEnabled: false,
-                selectionEnabled: false,
-                popoutWholeStack: false,
-                blockedPopoutsThrowError: true,
-                closePopoutsOnUnload: true,
-                responsiveMode: 'always',
-                hasHeaders: true,
-                showPopoutIcon: false,
-                showMaximiseIcon: true,
-                showCloseIcon: false,
-            },
-            dimensions: {
-                headerHeight: 25,
-            },
-            content: goldenLayoutContents,
-        };
-        const dashboardContainer = document.getElementById(dashboardContainerId);
-        const goldenLayout = new GoldenLayout(config, dashboardContainer);
-        const renderingWidgetClassNames = GoldenLayoutContentUtils.getReferredWidgetClassNames(goldenLayoutContents);
-        renderingWidgetClassNames.forEach(widgetName => goldenLayout.registerComponent(widgetName, WidgetRenderer));
-        goldenLayout.eventHub.on(Event.DASHBOARD_VIEWER_WIDGET_LOADED,
-            () => this.onWidgetLoadedEvent(renderingWidgetClassNames.length, this.props.dashboardId));
+        const goldenLayoutContents = this.props.goldenLayoutContents;
+        const goldenLayout = GoldenLayoutFactory.createForViewer(dashboardContainerId, goldenLayoutContents);
 
-        // Workaround suggested in https://github.com/golden-layout/golden-layout/pull/348#issuecomment-350839014
-        setTimeout(() => goldenLayout.init(), 0);
+        const numberOfWidgets = GoldenLayoutContentUtils.getReferredWidgetClassNames(goldenLayoutContents).length;
+        goldenLayout.eventHub.on(Event.DASHBOARD_VIEWER_WIDGET_LOADED,
+            () => this.onWidgetLoadedEvent(numberOfWidgets, this.props.dashboardId));
+
+        goldenLayout.initialize();
         this.goldenLayout = goldenLayout;
     }
 


### PR DESCRIPTION
## Purpose
Fixes #1016 

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
- Moved the widget pub-sub logic/handing into the `WidgetPubSubHub` class.
- The `WidgetPubSubHub` instance corresponding to the current dashboard is passed as a prop to the widget. `this.props.pubSubHub`
- `WidgetPubSubHub` will cache the last published message against publisher ID. When a subscriber comes to subscribe to a particular publisher, if there is a last published message, then that message is passed to that subscriber. 

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
