### PR TITLE
Fix names of last 2 widgets displayed in the widgets side pane in dashboard designer not being displayed

### DIFF
--- a/components/dashboards-web-component/src/designer/components/WidgetsSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/WidgetsSidePane.jsx
@@ -95,8 +95,10 @@ export default class WidgetsSidePane extends Component {
                                 onChange={event => this.setState({ filter: event.target.value })}
                             />
                         </div>
-                        <div style={{ height: '100%', overflowY: 'auto' }}>{this.widgets.map(
-                            widget => this.renderWidgetCard(widget))}</div>
+                        <div style={{ height: '100%', overflowY: 'auto' }}>
+                            {this.widgets.map(widget => this.renderWidgetCard(widget))}
+                            <div style={{ height: '10%' }} />
+                        </div>
                     </span>
                 );
             }


### PR DESCRIPTION
## Purpose
Fixes #1007 
![image](https://user-images.githubusercontent.com/11549922/44564765-6bbdfb80-a782-11e8-8ac0-856e0976710b.png)

## Goals
After:
![image](https://user-images.githubusercontent.com/11549922/44564743-40d3a780-a782-11e8-9ced-baa95efdea79.png)

## Approach
- Added a bottom padding `div`

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
