### PR TITLE
Fix getting generated widget Id when exporting a dashboard

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -423,7 +423,7 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
         for (PageContent content : contents) {
             if (content.getComponent() != null) {
                 if (UNIVERSAL_WIDGET.equals(content.getComponent())) {
-                    widgets.get(WidgetType.GENERATED).add(content.getTitle());
+                    widgets.get(WidgetType.GENERATED).add(content.getTitle().replaceAll(" ", "-"));
                 } else {
                     widgets.get(WidgetType.CUSTOM).add(content.getComponent());
                 }


### PR DESCRIPTION
## Purpose
This PR fixes getting generated widget ID instead of widget title when exporting a dashboard.