### PR TITLE
Fix issues in dashboard import feature

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApiProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApiProvider.java
@@ -28,7 +28,6 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.dashboards.core.DashboardMetadataProvider;
-import org.wso2.carbon.dashboards.core.WidgetMetadataProvider;
 import org.wso2.carbon.uiserver.api.App;
 import org.wso2.carbon.uiserver.spi.RestApiProvider;
 import org.wso2.msf4j.Microservice;
@@ -48,8 +47,7 @@ public class DashboardRestApiProvider implements RestApiProvider {
     public static final String DASHBOARD_PORTAL_APP_NAME = "portal";
     private static final Logger LOGGER = LoggerFactory.getLogger(DashboardRestApiProvider.class);
 
-    private DashboardMetadataProvider dashboardDataProvider;
-    private WidgetMetadataProvider widgetMetadataProvider;
+    private DashboardMetadataProvider dashboardMetadataProvider;
 
     @Activate
     protected void activate(BundleContext bundleContext) {
@@ -73,20 +71,6 @@ public class DashboardRestApiProvider implements RestApiProvider {
     protected void unsetDashboardMetadataProvider(DashboardMetadataProvider dashboardDataProvider) {
         this.dashboardDataProvider = null;
         LOGGER.debug("DashboardMetadataProvider '{}' unregistered.", dashboardDataProvider.getClass().getName());
-    }
-
-    @Reference(service = WidgetMetadataProvider.class,
-               cardinality = ReferenceCardinality.MANDATORY,
-               policy = ReferencePolicy.DYNAMIC,
-               unbind = "unsetWidgetMetadataProvider")
-    protected void setWidgetMetadataProvider(WidgetMetadataProvider widgetMetadataProvider) {
-        this.widgetMetadataProvider = widgetMetadataProvider;
-        LOGGER.debug("WidgetMetadataProvider '{}' registered.", widgetMetadataProvider.getClass().getName());
-    }
-
-    protected void unsetWidgetMetadataProvider(WidgetMetadataProvider widgetMetadataProvider) {
-        this.widgetMetadataProvider = null;
-        LOGGER.debug("WidgetMetadataProvider '{}' registered.", widgetMetadataProvider.getClass().getName());
     }
 
     @Override

--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApiProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApiProvider.java
@@ -64,12 +64,12 @@ public class DashboardRestApiProvider implements RestApiProvider {
                policy = ReferencePolicy.DYNAMIC,
                unbind = "unsetDashboardMetadataProvider")
     protected void setDashboardMetadataProvider(DashboardMetadataProvider dashboardDataProvider) {
-        this.dashboardDataProvider = dashboardDataProvider;
+        this.dashboardMetadataProvider = dashboardDataProvider;
         LOGGER.debug("DashboardMetadataProvider '{}' registered.", dashboardDataProvider.getClass().getName());
     }
 
     protected void unsetDashboardMetadataProvider(DashboardMetadataProvider dashboardDataProvider) {
-        this.dashboardDataProvider = null;
+        this.dashboardMetadataProvider = null;
         LOGGER.debug("DashboardMetadataProvider '{}' unregistered.", dashboardDataProvider.getClass().getName());
     }
 
@@ -80,10 +80,11 @@ public class DashboardRestApiProvider implements RestApiProvider {
 
     @Override
     public Map<String, Microservice> getMicroservices(App app) {
+        dashboardMetadataProvider.init(app);
         Map<String, Microservice> microservices = new HashMap<>(2);
-        microservices.put(DashboardRestApi.API_CONTEXT_PATH, new DashboardRestApi(dashboardDataProvider));
-        widgetMetadataProvider.setDashboardApp(app);
-        microservices.put(WidgetRestApi.API_CONTEXT_PATH, new WidgetRestApi(widgetMetadataProvider));
+        microservices.put(DashboardRestApi.API_CONTEXT_PATH, new DashboardRestApi(dashboardMetadataProvider));
+        microservices.put(WidgetRestApi.API_CONTEXT_PATH,
+                          new WidgetRestApi(dashboardMetadataProvider.getWidgetMetadataProvider()));
         return microservices;
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.analytics.permissions.bean.Role;
 import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
 import org.wso2.carbon.dashboards.core.bean.importer.DashboardArtifact;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
+import org.wso2.carbon.uiserver.api.App;
 
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,22 @@ import java.util.Set;
  * @since 4.0.0
  */
 public interface DashboardMetadataProvider {
+
+    /**
+     * Initializes dashboard provider. This should be invoked before any operations.
+     *
+     * @param dashboardApp dashboard portal app
+     * @since 4.0.32
+     */
+    void init(App dashboardApp);
+
+    /**
+     * Returns the widget provider.
+     *
+     * @return widget provider.
+     * @since 4.0.32
+     */
+    WidgetMetadataProvider getWidgetMetadataProvider();
 
     /**
      * Returns the dashboard for the given URL.

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
@@ -60,17 +60,6 @@ public interface WidgetMetadataProvider {
     Set<WidgetMetaInfo> getAllWidgetConfigurations() throws DashboardException;
 
     /**
-     * Get configurations of given set of widgets.
-     *
-     * @since 4.0.29
-     *
-     * @param widgetIds Set of widget Ids
-     * @return Set of widget configurations
-     * @throws DashboardException If an error occurred when reading or processing configurations
-     */
-    Set<WidgetMetaInfo> getWidgetConfigurations(Set<String> widgetIds) throws DashboardException;
-
-    /**
      * Get generated widget configurations.
      *
      * @since 4.0.29

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/WidgetMetadataProvider.java
@@ -22,7 +22,6 @@ import org.wso2.carbon.dashboards.core.bean.importer.WidgetType;
 import org.wso2.carbon.dashboards.core.bean.widget.GeneratedWidgetConfigs;
 import org.wso2.carbon.dashboards.core.bean.widget.WidgetMetaInfo;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
-import org.wso2.carbon.uiserver.api.App;
 
 import java.util.Optional;
 import java.util.Set;
@@ -97,17 +96,4 @@ public interface WidgetMetadataProvider {
      * @throws DashboardException
      */
     boolean isWidgetPresent(String widgetName, WidgetType widgetType) throws DashboardException;
-    /**
-     * Sets the dashboard portal app to this provider.
-     *
-     * @param dashboardApp dashboard portal app
-     */
-    void setDashboardApp(App dashboardApp);
-
-    /**
-     * Returns the dashboard portal app of this provider.
-     *
-     * @return dashboard portal app
-     */
-    App getDashboardApp();
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
@@ -19,14 +19,6 @@
 package org.wso2.carbon.dashboards.core.internal;
 
 
-import com.google.gson.Gson;
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.dashboards.core.DashboardMetadataProvider;
@@ -57,7 +49,6 @@ import java.util.Locale;
  *
  * @since 4.2.8
  */
-@Component(immediate = true)
 public class DashboardImporter {
     private static final Logger log = LoggerFactory.getLogger(DashboardImporter.class);
     private static final String ARTIFACT_EXTENSION = "json";

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/StartupListener.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/StartupListener.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.internal;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.analytics.idp.client.core.api.IdPClient;
+import org.wso2.carbon.analytics.permissions.PermissionManager;
+import org.wso2.carbon.analytics.permissions.PermissionProvider;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.dashboards.core.DashboardMetadataProvider;
+import org.wso2.carbon.dashboards.core.bean.DashboardConfigurations;
+import org.wso2.carbon.datasource.core.api.DataSourceService;
+
+/**
+ * aas
+ */
+@Component(immediate = true)
+public class StartupListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StartupListener.class);
+
+    private DataSourceService dataSourceService;
+    private DashboardConfigurations dashboardConfigurations;
+    private PermissionProvider permissionProvider;
+    private IdPClient idPClient;
+
+    @Reference(service = DataSourceService.class,
+               cardinality = ReferenceCardinality.AT_LEAST_ONE,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetDataSourceService")
+    protected void setDataSourceService(DataSourceService dataSourceService) {
+        this.dataSourceService = dataSourceService;
+    }
+
+    protected void unsetDataSourceService(DataSourceService dataSourceService) {
+        this.dataSourceService = null;
+    }
+
+    @Reference(service = ConfigProvider.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetConfigProvider")
+    protected void setConfigProvider(ConfigProvider configProvider) {
+        try {
+            this.dashboardConfigurations = configProvider.getConfigurationObject(DashboardConfigurations.class);
+        } catch (ConfigurationException e) {
+            LOGGER.error("Cannot load dashboard configurations from 'deployment.yaml'. Falling-back to defaults.", e);
+            this.dashboardConfigurations = new DashboardConfigurations();
+        }
+    }
+
+    protected void unsetConfigProvider(ConfigProvider configProvider) {
+        LOGGER.debug("An instance of class '{}' unregistered as a config provider.",
+                     configProvider.getClass().getName());
+    }
+
+    @Reference(service = PermissionManager.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetPermissionManager"
+    )
+    protected void setPermissionManager(PermissionManager permissionManager) {
+        this.permissionProvider = permissionManager.getProvider();
+    }
+
+    protected void unsetPermissionManager(PermissionManager permissionManager) {
+        this.permissionProvider = null;
+    }
+
+    @Reference(
+            service = IdPClient.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdPClient"
+    )
+    protected void setIdPClient(IdPClient client) {
+        this.idPClient = client;
+    }
+
+    protected void unsetIdPClient(IdPClient client) {
+        this.idPClient = null;
+    }
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        DashboardMetadataProvider dashboardMetadataProvider = new DashboardMetadataProviderImpl(dataSourceService,
+                                                                                                dashboardConfigurations,
+                                                                                                permissionProvider,
+                                                                                                idPClient);
+        bundleContext.registerService(DashboardMetadataProvider.class, dashboardMetadataProvider, null);
+        LOGGER.debug("{} activated.", this.getClass().getName());
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        LOGGER.debug("{} deactivated.", this.getClass().getName());
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
@@ -17,8 +17,6 @@
  */
 package org.wso2.carbon.dashboards.core.internal;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.carbon.dashboards.core.WidgetMetadataProvider;
 import org.wso2.carbon.dashboards.core.bean.DashboardConfigurations;
 import org.wso2.carbon.dashboards.core.bean.importer.WidgetType;
@@ -44,8 +42,6 @@ import java.util.stream.Collectors;
  */
 public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WidgetMetadataProviderImpl.class);
-    private static final String APP_NAME_DASHBOARD = "portal";
     private static final String EXTENSION_TYPE_WIDGETS = "widgets";
 
     private final App dashboardApp;

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
@@ -107,7 +107,7 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
             widgetMetaInfo.setConfigs(widgetConfigs);
             return Optional.ofNullable(widgetMetaInfo);
         } else {
-            return getDashboardApp().getExtension(EXTENSION_TYPE_WIDGETS, widgetId)
+            return dashboardApp.getExtension(EXTENSION_TYPE_WIDGETS, widgetId)
                     .map(WidgetConfigurationReader::getConfiguration);
         }
     }
@@ -161,7 +161,7 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
 
     @Override
     public Set<WidgetMetaInfo> getAllWidgetConfigurations() throws DashboardException {
-        Set<WidgetMetaInfo> widgetMetaInfoSet = getDashboardApp().getExtensions(EXTENSION_TYPE_WIDGETS).stream()
+        Set<WidgetMetaInfo> widgetMetaInfoSet = dashboardApp.getExtensions(EXTENSION_TYPE_WIDGETS).stream()
                 .map(WidgetConfigurationReader::getConfiguration)
                 .collect(Collectors.toSet());
         if (isDaoInitialized) {
@@ -191,40 +191,5 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
     @Override
     public void delete(String widgetId) throws DashboardException {
         widgetMetadataDao.delete(widgetId);
-    }
-
-    @Override
-    public void setDashboardApp(App dashboardApp) {
-        Objects.requireNonNull(dashboardApp, "Dashboard portal web app cannot be null.");
-        this.dashboardApp = dashboardApp;
-    }
-
-    @Override
-    public App getDashboardApp() {
-        return dashboardApp;
-    }
-
-    @Reference(service = DataSourceService.class,
-               cardinality = ReferenceCardinality.AT_LEAST_ONE,
-               policy = ReferencePolicy.DYNAMIC,
-               unbind = "unsetDataSourceService")
-    protected void setDataSourceService(DataSourceService dataSourceService) {
-        this.dataSourceService = dataSourceService;
-    }
-
-    protected void unsetDataSourceService(DataSourceService dataSourceService) {
-        this.dataSourceService = null;
-    }
-
-    @Reference(service = ConfigProvider.class,
-               cardinality = ReferenceCardinality.MANDATORY,
-               policy = ReferencePolicy.DYNAMIC,
-               unbind = "unsetConfigProvider")
-    protected void setConfigProvider(ConfigProvider configProvider) {
-        this.configProvider = configProvider;
-    }
-
-    protected void unsetConfigProvider(ConfigProvider configProvider) {
-        this.configProvider = null;
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
@@ -82,7 +82,7 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
             widgetMetaInfo.setId(generatedWidgetConfigs.getId());
             widgetMetaInfo.setName(generatedWidgetConfigs.getName());
             widgetMetaInfo.setConfigs(widgetConfigs);
-            return Optional.ofNullable(widgetMetaInfo);
+            return Optional.of(widgetMetaInfo);
         } else {
             return dashboardApp.getExtension(EXTENSION_TYPE_WIDGETS, widgetId)
                     .map(WidgetConfigurationReader::getConfiguration);
@@ -145,8 +145,9 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
 
     @Override
     public Set<GeneratedWidgetConfigs> getGeneratedWidgetConfigs(Set<String> widgetIds) throws DashboardException {
-        Set<GeneratedWidgetConfigs> generatedWidgetIdSet = widgetMetadataDao.getGeneratedWidgetIdSet();
-        return generatedWidgetIdSet.stream().filter(w -> widgetIds.contains(w.getId())).collect(Collectors.toSet());
+        return widgetMetadataDao.getGeneratedWidgetIdSet().stream()
+                .filter(generatedWidgetConfigs -> widgetIds.contains(generatedWidgetConfigs.getId()))
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
@@ -182,36 +182,7 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
         return widgetMetaInfoSet;
     }
 
-    /**
-     * Get configurations of given set of widgets.
-     *
-     * @param widgetIds Set of widget Ids
-     * @return Set of widget configurations
-     * @throws DashboardException If an error occurred when reading or processing configurations
-     */
     @Override
-    public Set<WidgetMetaInfo> getWidgetConfigurations(Set<String> widgetIds) throws DashboardException {
-        Set<WidgetMetaInfo> widgetMetaInfoSet = new HashSet<>();
-        if (isDaoInitialized) {
-            Set<GeneratedWidgetConfigs> generatedWidgetIdSet = widgetMetadataDao.getGeneratedWidgetIdSet();
-            for (GeneratedWidgetConfigs generatedWidgetConfigs: generatedWidgetIdSet) {
-                if (widgetIds.contains(generatedWidgetConfigs.getId())) {
-                    WidgetMetaInfo widgetMetaInfo = new WidgetMetaInfo();
-                    WidgetConfigs widgetConfigs = new WidgetConfigs();
-                    widgetMetaInfo.setId(generatedWidgetConfigs.getId());
-                    widgetMetaInfo.setName(generatedWidgetConfigs.getName());
-                    widgetConfigs.setPubsub(generatedWidgetConfigs.getPubsub());
-                    widgetConfigs.setMetadata(generatedWidgetConfigs.getMetadata());
-                    widgetConfigs.setGenerated(true);
-                    widgetMetaInfo.setVersion(generatedWidgetConfigs.getVersion());
-                    widgetMetaInfo.setConfigs(widgetConfigs);
-                    widgetMetaInfoSet.add(widgetMetaInfo);
-                }
-            }
-        }
-        return widgetMetaInfoSet;
-    }
-
     public Set<GeneratedWidgetConfigs> getGeneratedWidgetConfigs(Set<String> widgetIds) throws DashboardException {
         Set<GeneratedWidgetConfigs> generatedWidgetIdSet = widgetMetadataDao.getGeneratedWidgetIdSet();
         return generatedWidgetIdSet.stream().filter(w -> widgetIds.contains(w.getId())).collect(Collectors.toSet());

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/database/WidgetMetadataDaoFactory.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/database/WidgetMetadataDaoFactory.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.dashboards.core.internal.database;
 
-import org.wso2.carbon.config.ConfigurationException;
-import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.dashboards.core.bean.DashboardConfigurations;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
@@ -39,24 +37,19 @@ public class WidgetMetadataDaoFactory {
     /**
      * Creates a new DAO.
      *
-     * @param dataSourceService data sources service
-     * @param configProvider    config provider
+     * @param dataSourceService       data sources service
+     * @param dashboardConfigurations dashboard configurations
      * @return DAO
      * @throws DashboardException if cannot find required data source or load dashboard configurations
      */
-    public static WidgetMetadataDao createDao(DataSourceService dataSourceService, ConfigProvider configProvider)
+    public static WidgetMetadataDao createDao(DataSourceService dataSourceService,
+                                              DashboardConfigurations dashboardConfigurations)
             throws DashboardException {
         DataSource dataSource;
         try {
             dataSource = (DataSource) dataSourceService.getDataSource(DATA_SOURCE_NAME_DASHBOARD);
         } catch (DataSourceException e) {
             throw new DashboardException("Cannot find data source named '" + DATA_SOURCE_NAME_DASHBOARD + "'.", e);
-        }
-        DashboardConfigurations dashboardConfigurations;
-        try {
-            dashboardConfigurations = configProvider.getConfigurationObject(DashboardConfigurations.class);
-        } catch (ConfigurationException e) {
-            throw new DashboardException("Cannot load dashboard configurations from 'deployment.yaml'.", e);
         }
         QueryManager queryManager = new QueryManager(dashboardConfigurations);
         return new WidgetMetadataDao(dataSource, queryManager);

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/io/DashboardArtifactHandler.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/io/DashboardArtifactHandler.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.dashboards.core.internal.io;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.dashboards.core.bean.importer.DashboardArtifact;
+import org.wso2.carbon.dashboards.core.exception.DashboardException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Handles dashboard JSON files.
+ *
+ * @since 4.0.32
+ */
+public class DashboardArtifactHandler {
+
+    private static final String ARTIFACT_EXTENSION = ".json";
+    private static final Gson GSON = new Gson();
+    private static final Logger LOGGER = LoggerFactory.getLogger(DashboardArtifactHandler.class);
+
+    /**
+     * Loads dashboard artifacts in the given directory.
+     *
+     * @param directory path to directory
+     * @return loaded dashboards
+     * @throws DashboardException if cannot read files from the directory
+     */
+    public static Map<String, DashboardArtifact> readArtifactsIn(Path directory) throws DashboardException {
+        Set<Path> filePaths;
+        try {
+            filePaths = Files.list(directory)
+                    .filter(DashboardArtifactHandler::isValidArtifact)
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw new DashboardException("Cannot list dashboard artifacts in '" + directory + "'.", e);
+        }
+
+        Map<String, DashboardArtifact> dashboardArtifacts = new HashMap<>();
+        for (Path filePath : filePaths) {
+            try {
+                String fileContent = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
+                DashboardArtifact dashboardArtifact = GSON.fromJson(fileContent, DashboardArtifact.class);
+                dashboardArtifacts.put(filePath.toAbsolutePath().toString(), dashboardArtifact);
+            } catch (IOException e) {
+                throw new DashboardException("Cannot read dashboard artifact '" + filePath + "'.", e);
+            } catch (JsonSyntaxException e) {
+                LOGGER.warn("Dashboard artifact '{}' is invalid and is ignored.", filePath, e);
+            }
+        }
+        return dashboardArtifacts;
+    }
+
+    private static boolean isValidArtifact(Path filePath) {
+        return Files.isRegularFile(filePath) && getFileName(filePath).endsWith(ARTIFACT_EXTENSION);
+    }
+
+    private static String getFileName(Path filePath) {
+        Path fileName = filePath.getFileName();
+        return (fileName == null) ? "" : fileName.toString();
+    }
+
+    /**
+     * Marks the given dashboard artifact as 'imported'.
+     *
+     * @param artifactFilePath path to dashboard artifact
+     */
+    public static void markArtifactAsImported(String artifactFilePath) {
+        Path artifactPath = Paths.get(artifactFilePath);
+        try {
+            Files.move(artifactPath, artifactPath.resolveSibling(getFileName(artifactPath) + ".imported"));
+        } catch (IOException e) {
+            LOGGER.warn("Cannot mark dashboard artifact '{}' as imported. Hence, it will be re-imported in next " +
+                        "server startup.", artifactFilePath, e);
+        }
+    }
+}

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImplTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImplTest.java
@@ -34,13 +34,6 @@ import java.util.Collections;
 public class WidgetMetadataProviderImplTest {
 
     @Test
-    void testSetDashboardApp() {
-        WidgetMetadataProviderImpl widgetInfoProvider = new WidgetMetadataProviderImpl();
-        Assertions.assertThrows(NullPointerException.class,
-                                () -> widgetInfoProvider.setDashboardApp(null));
-    }
-
-    @Test
     void testGetWidgetConfigurationOfAbsentWidget() throws DashboardException {
         WidgetMetadataProviderImpl widgetInfoProvider = createWidgetInfoProvider();
         Assertions.assertFalse(widgetInfoProvider.getWidgetConfiguration("table").isPresent(),

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImplTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImplTest.java
@@ -21,10 +21,13 @@ package org.wso2.carbon.dashboards.core.internal;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
+import org.wso2.carbon.dashboards.core.internal.database.WidgetMetadataDao;
 import org.wso2.carbon.uiserver.api.App;
 import org.wso2.carbon.uiserver.api.Extension;
 
 import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Test cases for {@link WidgetMetadataProviderImpl} class.
@@ -53,13 +56,6 @@ public class WidgetMetadataProviderImplTest {
         Assertions.assertEquals(1, widgetInfoProvider.getAllWidgetConfigurations().size());
     }
 
-    @Test
-    void testOthers() {
-        WidgetMetadataProviderImpl widgetInfoProvider = new WidgetMetadataProviderImpl();
-        widgetInfoProvider.activate(null);
-        widgetInfoProvider.deactivate(null);
-    }
-
     private static App createPortalApp() {
         Extension chartWidget = new Extension("LineChart", "widgets", "src/test/resources/LineChart");
         return new App("portal", "/portal", Collections.emptySortedSet(), Collections.singleton(chartWidget),
@@ -68,8 +64,7 @@ public class WidgetMetadataProviderImplTest {
 
     private static WidgetMetadataProviderImpl createWidgetInfoProvider() {
         App portalApp = createPortalApp();
-        WidgetMetadataProviderImpl widgetInfoProvider = new WidgetMetadataProviderImpl();
-        widgetInfoProvider.setDashboardApp(portalApp);
-        return widgetInfoProvider;
+        WidgetMetadataDao dao = mock(WidgetMetadataDao.class);
+        return new WidgetMetadataProviderImpl(portalApp, dao);
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/database/WidgetMetadataDaoFactoryTest.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/test/java/org/wso2/carbon/dashboards/core/internal/database/WidgetMetadataDaoFactoryTest.java
@@ -20,8 +20,6 @@ package org.wso2.carbon.dashboards.core.internal.database;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.wso2.carbon.config.ConfigurationException;
-import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.dashboards.core.bean.DashboardConfigurations;
 import org.wso2.carbon.dashboards.core.exception.DashboardException;
 import org.wso2.carbon.datasource.core.api.DataSourceService;
@@ -30,7 +28,6 @@ import org.wso2.carbon.datasource.core.exception.DataSourceException;
 import javax.sql.DataSource;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,24 +42,10 @@ public class WidgetMetadataDaoFactoryTest {
     void testCreateDaoWhenDataSourceServiceThrowException() throws Exception {
         DataSourceService dataSourceService = mock(DataSourceService.class);
         when(dataSourceService.getDataSource(anyString())).thenThrow(DataSourceException.class);
-        ConfigProvider configProvider = mock(ConfigProvider.class);
+        DashboardConfigurations dashboardConfigurations = new DashboardConfigurations();
 
         Assertions.assertThrows(DashboardException.class,
-                                () -> WidgetMetadataDaoFactory.createDao(dataSourceService, configProvider));
-    }
-
-    @Test
-    void testCreateDaoWhenConfigProviderThrowException() throws Exception {
-        DataSource dataSource = mock(DataSource.class);
-        DataSourceService dataSourceService = mock(DataSourceService.class);
-        when(dataSourceService.getDataSource(anyString())).thenReturn(dataSource);
-
-        ConfigProvider configProvider = mock(ConfigProvider.class);
-        when(configProvider.getConfigurationObject(eq(DashboardConfigurations.class)))
-                .thenThrow(ConfigurationException.class);
-
-        Assertions.assertThrows(DashboardException.class,
-                                () -> WidgetMetadataDaoFactory.createDao(dataSourceService, configProvider));
+                                () -> WidgetMetadataDaoFactory.createDao(dataSourceService, dashboardConfigurations));
     }
 
     @Test
@@ -70,13 +53,10 @@ public class WidgetMetadataDaoFactoryTest {
         DataSource dataSource = mock(DataSource.class);
         DataSourceService dataSourceService = mock(DataSourceService.class);
         when(dataSourceService.getDataSource(anyString())).thenReturn(dataSource);
-
-        ConfigProvider configProvider = mock(ConfigProvider.class);
-        when(configProvider.getConfigurationObject(eq(DashboardConfigurations.class)))
-                .thenReturn(new DashboardConfigurations());
+        DashboardConfigurations dashboardConfigurations = new DashboardConfigurations();
 
         try {
-            WidgetMetadataDaoFactory.createDao(dataSourceService, configProvider);
+            WidgetMetadataDaoFactory.createDao(dataSourceService, dashboardConfigurations);
         } catch (DashboardException e) {
             Assertions.fail("DAO instantiation failed", e);
         }


### PR DESCRIPTION
## Purpose
- Fixes https://github.com/wso2/product-sp/issues/773

## Goals
- Improve error handling and error/warn messages when importing dashboards in server startup.
- Fix not considering widgets resides in `<SP_HOME>/deployment/web-ui-apps/portal/extensions/widgets/` directory.
- Reduce OSGi reference complexity in dashboard core bundle.
- Improve unit test cases.

## Approach
- Using NIO APIs (instead of IO APIs) to read, rename dashboard JSON files.

## Automation tests
 - Unit tests 
   improvements/fixes for existing unit tests
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
