### PR TITLE
Add ability to configure widget title 

### DIFF
--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -138,6 +138,9 @@ export default class WidgetRenderer extends Component {
 
     handleWidgetConfigUpdate(newConfig) {
         if (this.props.id === newConfig.props.id) {
+            if (newConfig.props.configs.options.headerTitle) {
+                newConfig.displayName = newConfig.props.configs.options.headerTitle;
+            }
             this.setState({ reRenderWidget: true });
         }
     }

--- a/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
@@ -130,7 +130,7 @@ export default class DashboardRenderer extends Component {
                 });
             }
             const itemConfig = {
-                title: widget.name,
+                title: '[' + (widget.displayName || widget.name) + ']',
                 type: 'react-component',
                 component: widget.configs.isGenerated ? 'UniversalWidget' : widget.id,
                 props: {

--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -135,6 +135,9 @@ export default class DashboardRenderer extends Component {
             if (typeof isHeaderShown != 'undefined'){
                 widgetContent.header.show = isHeaderShown;
             }
+            if (widgetContent.displayName) {
+                widgetContent.title = widgetContent.displayName;
+            }
         });
 
         const goldenLayout = GoldenLayoutFactory.createForViewer(dashboardContainerId, goldenLayoutContents);


### PR DESCRIPTION
## Purpose
Resolves #1041 1041

## Goals
Dashboard designer will be able to change the displayed widget title name by using this feature. 

## Approach
Widget author needs to add a config similar to the below in to his widgetConf.json file.

{
  "name": "UserInfo",
  "id": "UserInfo",
  "thumbnailURL": "",
  "displayName":"User Info",
  "configs": {
    "pubsub": {
      "types": [
        "publisher"
      ]
    },
    "options": [
      {
        "id": "header",
        "title": "Header",
        "type": {
          "name": "BOOLEAN",
          "possibleValues": [
            true,
            false
          ]
        },
        "defaultValue": true
      },
      **{
        "id": "headerTitle",
        "title": "Widget Display Name",
        "type": {
          "name": "TEXT",
          "possibleValues": [
          ]
        },
        "defaultValue": "Title1"
      }**
    ]
  }
}

Afterwards by clicking the widget settings icon in the dashboard designer, user can change the display name.