### PR TITLE
Fix reading widget ID on dashboard export

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/PageContent.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/PageContent.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.dashboards.core.bean.importer;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -31,6 +32,7 @@ public class PageContent {
     private String type;
     private String component;
     private Set<PageContent> content = new HashSet<>();
+    private HashMap<String, Object> props = new HashMap<>();
 
     /**
      * Returns widget title.
@@ -100,5 +102,23 @@ public class PageContent {
      */
     public void setContent(Set<PageContent> content) {
         this.content = content;
+    }
+
+    /**
+     * Returns widget props.
+     *
+     * @return Props
+     */
+    public HashMap<String, Object> getProps() {
+        return props;
+    }
+
+    /**
+     * Set widget props.
+     *
+     * @param props Props
+     */
+    public void setProps(HashMap<String, Object> props) {
+        this.props = props;
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -366,7 +366,7 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
         for (PageContent content : contents) {
             if (content.getComponent() != null) {
                 if (UNIVERSAL_WIDGET.equals(content.getComponent())) {
-                    widgets.get(WidgetType.GENERATED).add(content.getTitle().replaceAll(" ", "-"));
+                    widgets.get(WidgetType.GENERATED).add((String) content.getProps().get("widgetID"));
                 } else {
                     widgets.get(WidgetType.CUSTOM).add(content.getComponent());
                 }


### PR DESCRIPTION
## Purpose
This PR fixes the issue with reading widget ID from generated widgets when exporting dashboards.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes