### PR TITLE
Fix widget config not geting saved in dashboard designer

### DIFF
--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -138,9 +138,6 @@ export default class WidgetRenderer extends Component {
 
     handleWidgetConfigUpdate(newConfig) {
         if (this.props.id === newConfig.props.id) {
-            if (newConfig.props.configs.options.headerTitle) {
-                newConfig.displayName = newConfig.props.configs.options.headerTitle;
-            }
             this.setState({ reRenderWidget: true });
         }
     }

--- a/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
@@ -243,6 +243,8 @@ export default class DashboardRenderer extends Component {
     }
 
     updateDashboardOnConfigChange() {
+        const updatingPage = this.getRenderingPage();
+        updatingPage.content = this.cleanDashboardJSON(this.goldenLayout.toConfig().content);
         this.props.updateDashboard();
     }
 

--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -133,8 +133,9 @@ export default class DashboardRenderer extends Component {
             if (isHeaderShown != null) {
                 widgetContent.header.show = isHeaderShown;
             }
-            if (widgetContent.displayName) {
-                widgetContent.title = widgetContent.displayName;
+            const headerTitle = _.get(widgetContent, 'props.configs.options.headerTitle');
+            if (headerTitle != null) {
+                widgetContent.title = headerTitle;
             }
         });
 


### PR DESCRIPTION
## Purpose
$subject.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Node v8.8.1
- NPM v5.4.2
- Tested using `UserInfo` widget with this [`widgetConf.json`](https://github.com/wso2/carbon-dashboards/pull/1042#issue-212959511)
 