### PR TITLE
Dependencies version bumps for carbon-dashboards v4.0.37 release

### DIFF
--- a/components/dashboards-web-component/package-lock.json
+++ b/components/dashboards-web-component/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@wso2-dashboards/widget": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.3.0.tgz",
-      "integrity": "sha512-CqCZ4+MepiskIYFMf+oynILWw6P3Hoe/plTk7j4t8P+Z47WFwx24oNWsXgadRRtlCl/CbNtpQqrzpDIknhswig==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@wso2-dashboards/widget/-/widget-1.4.0.tgz",
+      "integrity": "sha512-A+GEotkuA67yFFiNPlSFBqOgRRqeeuPx461npDePp7g8zS1kY7fb5MHGzs/cX0G8Pqzuu2a5XPUC1GcIOYRBvw==",
       "requires": {
         "axios": "0.17.1"
       },

--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/wso2/carbon-dashboards#readme",
   "dependencies": {
-    "@wso2-dashboards/widget": "^1.3.0",
+    "@wso2-dashboards/widget": "^1.4.0",
     "axios": "^0.16.2",
     "babel-polyfill": "^6.26.0",
     "brace": "^0.11.0",

--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
         <carbon.analytics.version>2.0.419</carbon.analytics.version>
         <carbon.analytics.version.range>[2.0.395, 3.0.0)</carbon.analytics.version.range>
         <!--Analytics common-->
-        <carbon.analytics-common.version>6.0.68</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.0.70</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.0.65, 7.0.0)</carbon.analytics-common.version.range>
 
         <!--OSGi-->

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
         <carbon.datasources.version>1.1.4</carbon.datasources.version>
 
         <!--Analytics-->
-        <carbon.analytics.version>2.0.412</carbon.analytics.version>
+        <carbon.analytics.version>2.0.419</carbon.analytics.version>
         <carbon.analytics.version.range>[2.0.395, 3.0.0)</carbon.analytics.version.range>
         <!--Analytics common-->
         <carbon.analytics-common.version>6.0.68</carbon.analytics-common.version>


### PR DESCRIPTION
## Purpose
- Bump base widget version to v1.4.0 in dashboard web component
- Bump carbon-analytics version to v2.0.419
- Bump carbon-analytics-common version to v6.0.70
