### PR TITLE
Fix setting default theme in viewer

### DIFF
--- a/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/viewer/components/DashboardRenderer.jsx
@@ -152,6 +152,10 @@ export default class DashboardRenderer extends Component {
         goldenLayout.on('componentCreated', this.onGoldenLayoutComponentCreateEvent);
         goldenLayout.eventHub.on(Event.DASHBOARD_VIEWER_WIDGET_LOADED,
             () => this.onWidgetLoadedEvent(numberOfWidgets, this.props.dashboardId));
+        goldenLayout.on('initialised', () => {
+            // Set default theme
+            this.triggerThemeChangeEvent(this.props.theme);
+        });
         goldenLayout.initialize();
         this.goldenLayout = goldenLayout;
     }


### PR DESCRIPTION
## Purpose
Even though the theme is changed in the viewer, upon reloading the page current theme is not getting passed into widgets in the dashboards. This PR fixes that issue by passing the current theme into GoldenLayout on initializing.

Resolves https://github.com/wso2/carbon-dashboards/issues/993

