### PR TITLE
Remove defined executions for pre-clean & clean phases in exec-maven-plugin

### DIFF
--- a/components/dashboards-web-component/pom.xml
+++ b/components/dashboards-web-component/pom.xml
@@ -38,6 +38,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/components/universal-widget/pom.xml
+++ b/components/universal-widget/pom.xml
@@ -39,6 +39,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,7 @@
         <!--Maven Plugin-->
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <maven.exec.plugin.version>1.5.0</maven.exec.plugin.version>
+        <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
         <jacoco.maven.plugin.version>0.7.9</jacoco.maven.plugin.version>
         <junit-platform.surefire-provider.version>1.0.2</junit-platform.surefire-provider.version>
 
@@ -495,6 +496,20 @@
                     <groupId>org.wso2.carbon.maven</groupId>
                     <artifactId>carbon-feature-plugin</artifactId>
                     <version>${carbon.feature.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven.clean.plugin.version}</version>
+                    <configuration>
+                        <filesets>
+                            <fileset>
+                                <directory>${project.basedir}/node_modules</directory>
+                            </fileset>
+                            <fileset>
+                                <directory>${project.basedir}/dist</directory>
+                            </fileset>
+                        </filesets>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -529,38 +529,8 @@
                                 </arguments>
                             </configuration>
                         </execution>
-                        <!-- 'npm run clean' which is run in clean lifecycle needs 'rimraf' node module.
-                         Make sure it is installed  -->
                         <execution>
-                            <id>npm install rimraf (clean)</id>
-                            <goals>
-                                <goal>exec</goal>
-                            </goals>
-                            <phase>pre-clean</phase>
-                            <configuration>
-                                <executable>${npm.executable}</executable>
-                                <arguments>
-                                    <argument>install</argument>
-                                    <argument>rimraf</argument>
-                                </arguments>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>npm run clean (clean)</id>
-                            <goals>
-                                <goal>exec</goal>
-                            </goals>
-                            <phase>clean</phase>
-                            <configuration>
-                                <executable>${npm.executable}</executable>
-                                <arguments>
-                                    <argument>run</argument>
-                                    <argument>clean</argument>
-                                </arguments>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>npm run dev (compile)</id>
+                            <id>npm run build (compile and build)</id>
                             <goals>
                                 <goal>exec</goal>
                             </goals>

--- a/samples/widgets/Publisher/pom.xml
+++ b/samples/widgets/Publisher/pom.xml
@@ -58,6 +58,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/widgets/Subscriber/pom.xml
+++ b/samples/widgets/Subscriber/pom.xml
@@ -58,6 +58,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/widgets/UserInfo/pom.xml
+++ b/samples/widgets/UserInfo/pom.xml
@@ -58,6 +58,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/widgets/WidgetState/pom.xml
+++ b/samples/widgets/WidgetState/pom.xml
@@ -58,6 +58,9 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/widgets/sales-dashboard-widgets/CustomersByProduct/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/CustomersByProduct/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/CustomersPerYear/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/CustomersPerYear/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/OverallProductInfo/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/OverallProductInfo/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/OverallRevenueInfo/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/RevenueByCountry/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByCountry/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProduct/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProduct/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/RevenueByProductWithUserPreferences/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByProductWithUserPreferences/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/RevenueByRegion/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/RevenueByRegion/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/RevenuePerYear/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePerYear/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/samples/widgets/sales-dashboard-widgets/RevenuePercentage/pom.xml
+++ b/samples/widgets/sales-dashboard-widgets/RevenuePercentage/pom.xml
@@ -41,6 +41,9 @@
                 <artifactId>exec-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
## Purpose
$subject.

## Goals
- Reduce build time of `carbon-dashboards` repo.

## Approach
- Removed `npm install rimraf (clean)` and `npm run clean (clean)` executions from `exec-maven-plugin` in root `pom.xml`.
- Instead used `maven-clean-plugin` to delete `dist` & `node_modules` directories in the `clean` phase.

## Automation tests
Ran local builds for a freshly cloned `carbon-dashboards` repo.

|                               | Before      | After   	     |
|------------------------- |-------------- |-------------- |
| `mvn clean`           | 02:05 min | 2.478 s     |
| `mvn clean install` | 10:24 min | 08:48 min |

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Test environment
- Maven v3.3.9
 