### PR TITLE
Add missing keys in locale files(en,fr) for React-Intl wrappers

### DIFF
--- a/components/dashboards-web-component/public/locales/en.json
+++ b/components/dashboards-web-component/public/locales/en.json
@@ -85,9 +85,15 @@
   "page.height": "Height (px)",
   "page.height.reset": "Reset height",
   "page.height.overlay": "Height",
-  "report.generation.capture.button.title":"Capture current page",
-  "report.generation.page.size.title":"Page Size",
-  "report.generation.export.button.title":"Generate Report",
-  "report.generation.card.title":"Export Dashboard As PDF",
-  "report.generation.page.orientation.title":"Page Orientation"
+  "report.generation.capture.button.title": "Capture current page",
+  "report.generation.page.size.title": "Page Size",
+  "report.generation.export.button.title": "Generate Report",
+  "report.generation.card.title": "Export Dashboard As PDF",
+  "report.generation.page.orientation.title": "Page Orientation",
+  "delete.button": "Delete",
+  "widget-gen-wizard.title": "Widget Designer",
+  "widgets.loading": "Loading...",
+  "widgets.loading-failed": "Widgets Loading failed!",
+  "widget-configuration.pubsub.title": "Publishers",
+  "widgets.loading.dashboard": "Widget are still loading..."
 }

--- a/components/dashboards-web-component/public/locales/fr.json
+++ b/components/dashboards-web-component/public/locales/fr.json
@@ -83,9 +83,15 @@
   "page.height": "Hauteur (px)",
   "page.height.reset": "Réinitialiser hauteur",
   "page.height.overlay": "Hauteur",
-  "report.generation.capture.button.title":"Capturer la page en cours",
-  "report.generation.page.size.title":"Taille de la page",
-  "report.generation.export.button.title":"Générer un rapport",
-  "report.generation.card.title":"Exporter le tableau de bord en format PDF",
-  "report.generation.page.orientation.title":"Orientation de la page"
+  "report.generation.capture.button.title": "Capturer la page en cours",
+  "report.generation.page.size.title": "Taille de la page",
+  "report.generation.export.button.title": "Générer un rapport",
+  "report.generation.card.title": "Exporter le tableau de bord en format PDF",
+  "report.generation.page.orientation.title": "Orientation de la page",
+  "delete.button": "Effacer",
+  "widget-gen-wizard.title": "Widget Designer",
+  "widgets.loading": "Chargement...",
+  "widgets.loading-failed": "Le chargement des widgets a échoué!",
+  "widget-configuration.pubsub.title": "Les éditeurs",
+  "widgets.loading.dashboard": "Les widgets se chargent toujours ..."
 }


### PR DESCRIPTION
## Purpose
Some strings in the dashboard app use default strings due to missing the keys in the locale files. The missing links are included in the two files.

## Goals
To make the Internationalization work better

