### PR TITLE
Fix more menu icon of a dashboard card in the dashboards listing page

### DIFF
--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -50,7 +50,7 @@ const styles = {
         float: 'right',
         paddingRight: 0,
     },
-    moreButton: {
+    menuIcon: {
         float: 'right',
         padding: '4px',
         cursor: 'pointer',
@@ -235,7 +235,7 @@ class DashboardCard extends Component {
                                 <span style={styles.cardTitle}>{title}</span>
                                 {
                                     dashboard.hasOwnerPermission && dashboard.hasDesignerPermission &&
-                                    (<NavigationMoreVert onClick={this.handleMenuIconClick} style={styles.moreButton} />)
+                                    (<NavigationMoreVert onClick={this.handleMenuIconClick} style={styles.menuIcon} />)
                                 }
                             </div>
                         }

--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -52,7 +52,8 @@ const styles = {
     },
     moreButton: {
         float: 'right',
-        padding: '4px'
+        padding: '4px',
+        cursor: 'pointer',
     },
     cardTitle: {
         float: 'left',

--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -232,7 +232,10 @@ class DashboardCard extends Component {
                         title={
                             <div>
                                 <span style={styles.cardTitle}>{title}</span>
-                                <NavigationMoreVert onClick={this.handleMenuIconClick} style={styles.moreButton} />
+                                {
+                                    dashboard.hasOwnerPermission && dashboard.hasDesignerPermission &&
+                                    (<NavigationMoreVert onClick={this.handleMenuIconClick} style={styles.moreButton} />)
+                                }
                             </div>
                         }
                         titleStyle={styles.cardTitleText}


### PR DESCRIPTION
## Purpose
- Fix permissions not being checked on rendering the more menu icon
- Fix cursor being default instead of pointer in the more menu icon

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Test environment
- Node v8.8.1
- NPM v5.4.2
- Firefox 61.0.1 on Ubuntu 16.04
- Chrome 68.0.3440.106 on Ubuntu 16.04
- Chromium 68.0.3440.106 on Ubuntu 16.04
 