### PR TITLE
Fix for not saving page height and page deletion blackout issue

### DIFF
--- a/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
@@ -104,7 +104,6 @@ export default class DashboardRenderer extends Component {
             // Check whether the page height is difference for the same page.
             let changingPage = nextProps.dashboard.pages.find(p => p.id === nextProps.pageId);
             let newHeight = (changingPage === undefined) ? undefined:changingPage.height;
-            // let newHeight = nextProps.dashboard.pages.find(p => p.id === nextProps.pageId).height;
             if(newHeight != undefined){
                 if (this.pageHeight !== newHeight) {
                     this.pageHeight = newHeight;

--- a/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
+++ b/components/dashboards-web-component/src/designer/components/DashboardRenderer.jsx
@@ -102,12 +102,16 @@ export default class DashboardRenderer extends Component {
         }
         if (this.props.pageId === nextProps.pageId) {
             // Check whether the page height is difference for the same page.
-            let newHeight = nextProps.dashboard.pages.find(p => p.id === nextProps.pageId).height;
-            if (this.pageHeight !== newHeight) {
-                this.pageHeight = newHeight;
-                this.destroyGoldenLayout();
-                return true;
-            }
+            let changingPage = nextProps.dashboard.pages.find(p => p.id === nextProps.pageId);
+            let newHeight = (changingPage === undefined) ? undefined:changingPage.height;
+            // let newHeight = nextProps.dashboard.pages.find(p => p.id === nextProps.pageId).height;
+            if(newHeight != undefined){
+                if (this.pageHeight !== newHeight) {
+                    this.pageHeight = newHeight;
+                    this.destroyGoldenLayout();
+                    return true;
+                }
+            }            
         }
         if (this.state !== nextState) {
             return true;

--- a/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
+++ b/components/dashboards-web-component/src/designer/components/PagesSidePane.jsx
@@ -213,8 +213,7 @@ class PagesSidePane extends Component {
             const currentHeight = page.height;
             page.height = height;
             this.props.updateDashboard()
-                .then(() => {
-                    this.props.onDashboardUpdate(this.props.dashboard);
+                .then(() => {                    
                     resolve();
                 })
                 .catch(() => {


### PR DESCRIPTION
## Purpose
> In the Portal Component changing the height of the page is not affecting. If a newly created page is deleted the screen blacks out. Resolves #1093 
## Goals
> Fix bugs
