### PR TITLE
Add dashboard export UI

### DIFF
--- a/components/dashboards-web-component/public/locales/en.json
+++ b/components/dashboards-web-component/public/locales/en.json
@@ -40,6 +40,7 @@
   "settings.button": "Settings",
   "design.button": "Design",
   "view.button": "View",
+  "export.button":"Export",
   "delete": "Delete",
   "search.hint.text": "Search...",
   "dialog-box.confirmation.yes": "Yes",

--- a/components/dashboards-web-component/public/locales/fr.json
+++ b/components/dashboards-web-component/public/locales/fr.json
@@ -40,6 +40,7 @@
   "settings.button": "Paramètres",
   "design.button": "Conception",
   "view.button": "Vue",
+  "export.button":"Exportation",
   "delete": "Effacer",
   "search.hint.text": "Chercher...",
   "dialog-box.confirmation.yes": "Oui",

--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -26,7 +26,7 @@ import { NavigationMoreVert } from 'material-ui/svg-icons';
 
 import DashboardThumbnail from '../../utils/DashboardThumbnail';
 import DashboardAPI from '../../utils/apis/DashboardAPI';
-import DashboardExportor from '../../utils/DashboardExportor';
+import DashboardExporter from '../../utils/DashboardExporter';
 
 const styles = {
     card: {
@@ -177,7 +177,7 @@ class DashboardCard extends Component {
         if (dashboard.hasDesignerPermission) {
             exportMenuItem = (<MenuItem
                 primaryText={<FormattedMessage id="export.button" defaultMessage="Export" />}
-                onClick={() => DashboardExportor.handleDashboardExport(dashboardName, dashboardURL)}
+                onClick={() => DashboardExporter.exportDashboard(dashboardName, dashboardURL)}
             />);
         }
         let settingsMenuItem;

--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -75,6 +75,7 @@ class DashboardCard extends Component {
         this.hideDashboardDeleteConfirmDialog = this.hideDashboardDeleteConfirmDialog.bind(this);
         this.showDashboardDeleteConfirmDialog = this.showDashboardDeleteConfirmDialog.bind(this);
         this.handleDashboardDeletionConfirm = this.handleDashboardDeletionConfirm.bind(this);
+        this.handleDashboardExport = this.handleDashboardExport.bind(this);
 
         this.renderDashboardDeleteConfirmDialog = this.renderDashboardDeleteConfirmDialog.bind(this);
         this.renderDashboardDeletionSuccessMessage = this.renderDashboardDeletionSuccessMessage.bind(this);
@@ -141,6 +142,20 @@ class DashboardCard extends Component {
         );
     }
 
+    handleDashboardExport() {
+        const dashboard = this.props.dashboard;
+        const dashboardName = dashboard.name;
+        DashboardAPI.handleExportDashboard(dashboard.url).then((response) => {
+            const url = window.URL.createObjectURL(
+                new Blob([JSON.stringify(response.data, undefined, 2)]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', dashboardName + '.json');
+            document.body.appendChild(link);
+            link.click();
+        });
+    }
+
     renderDashboardDeletionSuccessMessage(dashboard) {
         return (<Snackbar
             open
@@ -170,6 +185,13 @@ class DashboardCard extends Component {
                 containerElement={<Link to={`/designer/${dashboard.url}`} />}
             />);
         }
+        let exportMenuItem;
+        if (dashboard.hasDesignerPermission) {
+            exportMenuItem = (<MenuItem
+                primaryText={<FormattedMessage id="export.button" defaultMessage="Export"/>}
+                onClick={this.handleDashboardExport}
+            />);
+        }
         let settingsMenuItem;
         let deleteMenuItem;
         if (dashboard.hasOwnerPermission) {
@@ -194,6 +216,7 @@ class DashboardCard extends Component {
                 <Menu>
                     {designMenuItem}
                     {settingsMenuItem}
+                    {exportMenuItem}
                     {deleteMenuItem}
                 </Menu>
             </Popover>

--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -26,6 +26,7 @@ import { NavigationMoreVert } from 'material-ui/svg-icons';
 
 import DashboardThumbnail from '../../utils/DashboardThumbnail';
 import DashboardAPI from '../../utils/apis/DashboardAPI';
+import DashboardExportor from '../../utils/DashboardExportor';
 
 const styles = {
     card: {
@@ -75,7 +76,6 @@ class DashboardCard extends Component {
         this.hideDashboardDeleteConfirmDialog = this.hideDashboardDeleteConfirmDialog.bind(this);
         this.showDashboardDeleteConfirmDialog = this.showDashboardDeleteConfirmDialog.bind(this);
         this.handleDashboardDeletionConfirm = this.handleDashboardDeletionConfirm.bind(this);
-        this.handleDashboardExport = this.handleDashboardExport.bind(this);
 
         this.renderDashboardDeleteConfirmDialog = this.renderDashboardDeleteConfirmDialog.bind(this);
         this.renderDashboardDeletionSuccessMessage = this.renderDashboardDeletionSuccessMessage.bind(this);
@@ -142,20 +142,6 @@ class DashboardCard extends Component {
         );
     }
 
-    handleDashboardExport() {
-        const dashboard = this.props.dashboard;
-        const dashboardName = dashboard.name;
-        DashboardAPI.handleExportDashboard(dashboard.url).then((response) => {
-            const url = window.URL.createObjectURL(
-                new Blob([JSON.stringify(response.data, undefined, 2)]));
-            const link = document.createElement('a');
-            link.href = url;
-            link.setAttribute('download', dashboardName + '.json');
-            document.body.appendChild(link);
-            link.click();
-        });
-    }
-
     renderDashboardDeletionSuccessMessage(dashboard) {
         return (<Snackbar
             open
@@ -186,10 +172,12 @@ class DashboardCard extends Component {
             />);
         }
         let exportMenuItem;
+        const dashboardName = dashboard.name;
+        const dashboardURL = dashboard.url;
         if (dashboard.hasDesignerPermission) {
             exportMenuItem = (<MenuItem
-                primaryText={<FormattedMessage id="export.button" defaultMessage="Export"/>}
-                onClick={this.handleDashboardExport}
+                primaryText={<FormattedMessage id="export.button" defaultMessage="Export" />}
+                onClick={() => DashboardExportor.handleDashboardExport(dashboardName, dashboardURL)}
             />);
         }
         let settingsMenuItem;

--- a/components/dashboards-web-component/src/utils/DashboardExporter.js
+++ b/components/dashboards-web-component/src/utils/DashboardExporter.js
@@ -20,7 +20,7 @@ import DashboardAPI from './apis/DashboardAPI';
 
 export default class DashboardExporter {
     /**
-     * Export Dashboard
+     * Exports the specified dashboard as a JSON.
      * @param {string} dashboardName name of the dashboard
      * @param {string} dashboardURL url of the dashboard
      */

--- a/components/dashboards-web-component/src/utils/DashboardExporter.js
+++ b/components/dashboards-web-component/src/utils/DashboardExporter.js
@@ -18,14 +18,14 @@
 
 import DashboardAPI from './apis/DashboardAPI';
 
-export default class DashboardExportor {
+export default class DashboardExporter {
     /**
      * Export Dashboard
      * @param {string} dashboardName name of the dashboard
      * @param {string} dashboardURL url of the dashboard
      */
-    static handleDashboardExport(dashboardName, dashboardURL) {
-        DashboardAPI.ExportDashboardByID(dashboardURL)
+    static exportDashboard(dashboardName, dashboardURL) {
+        DashboardAPI.exportDashboardByID(dashboardURL)
             .then((response) => {
                 const url = window.URL.createObjectURL(
                     new Blob([JSON.stringify(response.data, undefined, 2)]));
@@ -37,7 +37,8 @@ export default class DashboardExportor {
                 document.body.removeChild(link);
             })
             .catch((e) => {
-                console.error(e);
+                // TODO: Show a proper error message to the user
+                console.error(`Exporting dashboard ${dashboardName} with URL '${dashboardURL}' failed.`, e);
             });
     }
 }

--- a/components/dashboards-web-component/src/utils/DashboardExporter.js
+++ b/components/dashboards-web-component/src/utils/DashboardExporter.js
@@ -38,7 +38,7 @@ export default class DashboardExporter {
             })
             .catch((e) => {
                 // TODO: Show a proper error message to the user
-                console.error(`Exporting dashboard ${dashboardName} with URL '${dashboardURL}' failed.`, e);
+                console.error(`Exporting dashboard '${dashboardName}' with URL '${dashboardURL}' failed.`, e);
             });
     }
 }

--- a/components/dashboards-web-component/src/utils/DashboardExportor.js
+++ b/components/dashboards-web-component/src/utils/DashboardExportor.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import DashboardAPI from './apis/DashboardAPI';
+
+export default class DashboardExportor {
+    /**
+     * Export Dashboard
+     * @param {string} dashboardName name of the dashboard
+     * @param {string} dashboardURL url of the dashboard
+     */
+    static handleDashboardExport(dashboardName, dashboardURL) {
+        DashboardAPI.ExportDashboardByID(dashboardURL)
+            .then((response) => {
+                const url = window.URL.createObjectURL(
+                    new Blob([JSON.stringify(response.data, undefined, 2)]));
+                const link = document.createElement('a');
+                link.href = url;
+                link.setAttribute('download', dashboardName + '.json');
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            })
+            .catch((e) => {
+                console.error(e);
+            });
+    }
+}

--- a/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
+++ b/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
@@ -151,7 +151,7 @@ export default class DashboardAPI {
      * @param {string} dashboardId Dashboard ID
      * @returns {Promise} Promise
      */
-    static handleExportDashboard(dashboardId) {
+    static ExportDashboardByID(dashboardId) {
         return new DashboardAPI()
             .getHTTPClient()
             .get(`${dashboardId}/export`);

--- a/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
+++ b/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
@@ -144,4 +144,16 @@ export default class DashboardAPI {
             .getHTTPClient()
             .get(`/report-config`);
     }
+
+    /**
+     * Export Dashboard
+     *
+     * @param {string} dashboardId Dashboard ID
+     * @returns {Promise} Promise
+     */
+    static handleExportDashboard(dashboardId) {
+        return new DashboardAPI()
+            .getHTTPClient()
+            .get(`${dashboardId}/export`);
+    }
 }

--- a/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
+++ b/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
@@ -146,12 +146,12 @@ export default class DashboardAPI {
     }
 
     /**
-     * Export Dashboard
+     * Exports the specified dashboard as a JSON.
      *
      * @param {string} dashboardId Dashboard ID
      * @returns {Promise} Promise
      */
-    static ExportDashboardByID(dashboardId) {
+    static exportDashboardByID(dashboardId) {
         return new DashboardAPI()
             .getHTTPClient()
             .get(`${dashboardId}/export`);


### PR DESCRIPTION
**Purpose**
> Providing the UI support to export dashboards

**Approach**
> The dashboard can be downloaded as a JSON file which contains,
           -Dashboard definition
           -Generated widget definitions
           -Custom widget names

**Security checks**
>Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
>Ran FindSecurityBugs plugin and verified report? yes
>Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

**Test environment**
>NodeJs version : v8.8.1
>NPM version : 5.4.2
>JDK version: 1.8
>Operating system: Ubuntu 16.04
