### PR TITLE
[Dashboard] Close SidePane after selecting a page

### DIFF
--- a/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
+++ b/components/dashboards-web-component/src/viewer/DashboardViewPage.jsx
@@ -274,7 +274,10 @@ class DashboardViewPage extends Component {
                     insetChildren={!isLandingPage}
                     nestedItems={subPagesList}
                     open={!!subPagesList}
-                    onClick={() => history.push(this.getNavigationToPage(page.id))}
+                    onClick={() => {
+                        history.push(this.getNavigationToPage(page.id));
+                        this.setState({isSidePaneOpen: false});
+                    }}
                     className={isLandingPage ? 'list-item homePage' : 'list-item'}
                 />
             );


### PR DESCRIPTION
## Purpose
> Resolve issue #1134 SidePane doesn't close after selecting a page.

![vvv](https://user-images.githubusercontent.com/32201965/54025888-f5cf2e00-41c1-11e9-8fb4-ddd02c8ec1d0.png)
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

