### PR TITLE
[UniversalWidget] Clear the chart if data is empty

### DIFF
--- a/components/universal-widget/src/UniversalWidget.jsx
+++ b/components/universal-widget/src/UniversalWidget.jsx
@@ -164,11 +164,13 @@ export default class UniversalWidget extends Widget {
      * Handle data received
      * */
     handleWidgetData(data) {
-        if(data.data.length !== 0){
+        if (data.data.length !== 0) {
             this.setState({
                 metadata: data.metadata || this.state.metadata,
                 data: data.data
             })
+        } else {
+            this.setState({data: []});
         }
     }
 


### PR DESCRIPTION
## Purpose
> Fix #1142 
When there is no data, previously rendered chart is not cleared and it remains the same.

## Result after this fix

If there is data
![111](https://user-images.githubusercontent.com/32201965/55087782-a305d980-50d0-11e9-914d-00637eb06e7d.png)

If there is no data
![222](https://user-images.githubusercontent.com/32201965/55087814-b153f580-50d0-11e9-8c23-6457f4c9b59f.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes