### PR TITLE
Fix issues in dashboard import feature

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardCreatePage.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardCreatePage.jsx
@@ -137,7 +137,7 @@ class DashboardCreatePage extends Component {
                         content: [],
                     },
                 ],
-                properties: []
+                properties: {}
             },
         };
         new DashboardAPI()

--- a/components/dashboards-web-component/test/sales-dashboard.json
+++ b/components/dashboards-web-component/test/sales-dashboard.json
@@ -7,7 +7,7 @@
     "landingPage": "overview",
     "parentId": "0",
     "content": {
-      "properties": [],
+      "properties": {},
       "pages": [
         {
           "id": "overview",

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardMetadata.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardMetadata.java
@@ -34,7 +34,7 @@ public class DashboardMetadata {
     protected String description;
     protected String landingPage;
     protected String parentId;
-    protected DashboardMetadataContent content;
+    protected DashboardMetadataContent content = new DashboardMetadataContent();
     protected boolean hasOwnerPermission;
     protected boolean hasDesignerPermission;
     protected boolean hasViewerPermission;

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardMetadataContent.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardMetadataContent.java
@@ -18,7 +18,7 @@
  */
 package org.wso2.carbon.dashboards.core.bean;
 
-import com.google.gson.JsonElement;
+import com.google.gson.JsonArray;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +30,14 @@ import java.util.Map;
  */
 public class DashboardMetadataContent {
     private Map<String, String> properties = new HashMap<>();
-    private JsonElement[] pages;
+    private JsonArray pages;
+
+    public DashboardMetadataContent() {
+    }
+
+    public DashboardMetadataContent(JsonArray pages) {
+        this.pages = pages;
+    }
 
     /**
      * Get dashboard properties.
@@ -55,7 +62,7 @@ public class DashboardMetadataContent {
      *
      * @return Array of pages
      */
-    public JsonElement[] getPages() {
+    public JsonArray getPages() {
         return pages;
     }
 
@@ -64,7 +71,7 @@ public class DashboardMetadataContent {
      *
      * @param pages Array of pages
      */
-    public void setPages(JsonElement[] pages) {
+    public void setPages(JsonArray pages) {
         this.pages = pages;
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.dashboards.core.internal;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.idp.client.core.api.IdPClient;
@@ -341,16 +342,13 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
      * @return Set of widget IDs
      * @throws DashboardException If an error occurred while reading or processing dashboards
      */
-    private Map<WidgetType, Set<String>> findWidgets(DashboardMetadataContent dashboardMetadataContent)
-            throws DashboardException {
-        Page[] dashboardPages = new Page[dashboardMetadataContent.getPages().length];
-        for (int i = 0; i < dashboardMetadataContent.getPages().length; i++) {
-            dashboardPages[i] = new Gson().fromJson(dashboardMetadataContent.getPages()[i], Page.class);
-        }
+    private Map<WidgetType, Set<String>> findWidgets(DashboardMetadataContent dashboardMetadataContent) {
         Map<WidgetType, Set<String>> widgets = new HashMap<>();
         widgets.put(WidgetType.GENERATED, new HashSet<>());
         widgets.put(WidgetType.CUSTOM, new HashSet<>());
-        for (Page page : dashboardPages) {
+        Gson gson = new Gson();
+        for (JsonElement element : dashboardMetadataContent.getPages()) {
+            Page page = gson.fromJson(element, Page.class);
             findWidgets(page.getContent(), widgets);
         }
         return widgets;

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/database/DashboardMetadataDao.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/database/DashboardMetadataDao.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.dashboards.core.internal.database;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -260,8 +260,8 @@ public class DashboardMetadataDao {
         try {
             return new Gson().fromJson(content, DashboardMetadataContent.class);
         } catch (JsonParseException e) {
-            DashboardMetadataContent dashboardMetadataContent = new DashboardMetadataContent();
-            dashboardMetadataContent.setPages(new Gson().fromJson(content, JsonElement[].class));
+            JsonArray pages = new Gson().fromJson(content, JsonArray.class);
+            DashboardMetadataContent dashboardMetadataContent = new DashboardMetadataContent(pages);
             return dashboardMetadataContent;
         }
     }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/io/DashboardArtifactHandler.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/io/DashboardArtifactHandler.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.dashboards.core.internal.io;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +70,15 @@ public class DashboardArtifactHandler {
             try {
                 String fileContent = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
                 DashboardArtifact dashboardArtifact = GSON.fromJson(fileContent, DashboardArtifact.class);
+
+                // If the $.dashboard.content.pages is null, check for $.dashboard.pages
+                if (dashboardArtifact.getDashboard().getContent().getPages() == null) {
+                    JsonObject root = GSON.fromJson(fileContent, JsonObject.class);
+                    JsonArray pages = root.getAsJsonObject("dashboard").getAsJsonArray("pages");
+                    if (!pages.isJsonNull()) {
+                        dashboardArtifact.getDashboard().getContent().setPages(pages);
+                    }
+                }
                 dashboardArtifacts.put(filePath.toAbsolutePath().toString(), dashboardArtifact);
             } catch (IOException e) {
                 throw new DashboardException("Cannot read dashboard artifact '" + filePath + "'.", e);


### PR DESCRIPTION
## Purpose
With the changes in [1], the JSON structure of each dashboard has been changed as follows.

```
$.dashboard.pages -> $.dashboard.content.pages
```

Because of this change, when importing a dashboard with the previous dashboard JSON structure, will not be saved properly. This PR fixes that issue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs

[1] https://github.com/wso2/carbon-dashboards/pull/1144