### PR TITLE
Fix PRIMARY_KEY violation when dashboards are imported twice

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
@@ -102,20 +102,20 @@ public class DashboardImporter {
 
             // Deploy generated widgets if not available.
             for (GeneratedWidgetConfigs widgetConfigs : dashboardArtifact.getWidgets().getGenerated()) {
-                String widgetName = widgetConfigs.getName();
+                String widgetConfigsId = widgetConfigs.getId();
                 try {
-                    if (!widgetMetadataProvider.isWidgetPresent(widgetName, WidgetType.GENERATED)) {
+                    if (!widgetMetadataProvider.isWidgetPresent(widgetConfigsId, WidgetType.GENERATED)) {
                         widgetMetadataProvider.addGeneratedWidgetConfigs(widgetConfigs);
                     } else {
                         widgetMetadataProvider.updateGeneratedWidgetConfigs(widgetConfigs);
                     }
-                    LOGGER.debug("Successfully imported generated widget '{}' from dashboard '{}'.", widgetName,
+                    LOGGER.debug("Successfully imported generated widget '{}' from dashboard '{}'.", widgetConfigsId,
                             dashboardArtifactPath);
                 } catch (DashboardException e) {
                     LOGGER.warn(
                             "Cannot load generated widget '{}' which is included in the importing dashboard '{}'. " +
                             "Hence, dashboard will be imported partially.",
-                            widgetName, dashboardArtifactPath, e);
+                            widgetConfigsId, dashboardArtifactPath, e);
                     importedSuccessfully = false;
                 }
             }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/WidgetMetadataProviderImpl.java
@@ -102,6 +102,7 @@ public class WidgetMetadataProviderImpl implements WidgetMetadataProvider {
 
     @Override
     public boolean isWidgetPresent(String widgetName, WidgetType widgetType) throws DashboardException {
+        // TODO: 02/05/19 Custom widget filtering also to be changed with widgetName 
         switch (widgetType) {
             case CUSTOM:
                 return isCustomWidgetPresent(widgetName);


### PR DESCRIPTION
## Purpose
$subject

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes