### PR TITLE
Remove unnecessary configuration from web.xml

### DIFF
--- a/components/shindig-server/src/main/resources/web.xml
+++ b/components/shindig-server/src/main/resources/web.xml
@@ -42,7 +42,6 @@
             org.apache.shindig.extras.ShindigExtrasGuiceModule:
             org.apache.shindig.gadgets.admin.GadgetAdminModule:
             org.wso2.carbon.dashboard.shindig.features.WSO2ShindigFeaturesModule:
-            org.apache.shindig.wso2.ext.OverridingModule:
         </param-value>
     </context-param>
 


### PR DESCRIPTION
## Purpose
> We added this configuration earlier for a fix we did for shindig but turns out, Identity Server packs its own web.xml file. Therefore, this is not needed.
