### PR TITLE
Fix dashboard creator role

### DIFF
--- a/components/dashboards-web-component/src/listing/DashboardListingPage.jsx
+++ b/components/dashboards-web-component/src/listing/DashboardListingPage.jsx
@@ -26,6 +26,7 @@ import WidgetButton from '../common/WidgetButton';
 import UserMenu from '../common/UserMenu';
 import defaultTheme from '../utils/Theme';
 import DashboardAPI from '../utils/apis/DashboardAPI';
+import AuthManager from "../auth/utils/AuthManager";
 
 const styles = {
     thumbnailsWrapper: {
@@ -59,8 +60,10 @@ export default class DashboardListingPage extends Component {
         this.state = {
             dashboards: undefined,
             error: false,
+            hasCreatorPermission: false,
         };
         this.retrieveDashboards = this.retrieveDashboards.bind(this);
+        this.checkCreatorPermission = this.checkCreatorPermission.bind(this);
         this.renderDashboardThumbnails = this.renderDashboardThumbnails.bind(this);
     }
 
@@ -69,6 +72,7 @@ export default class DashboardListingPage extends Component {
      */
     componentDidMount() {
         this.retrieveDashboards();
+        this.checkCreatorPermission();
     }
 
     /**
@@ -87,6 +91,20 @@ export default class DashboardListingPage extends Component {
                     error: true,
                 });
             });
+    }
+
+    /**
+     * Check if the current user has creator permissions.
+     */
+    checkCreatorPermission() {
+        let username = AuthManager.getUser().username;
+        new DashboardAPI().hasCreatorPermission(username)
+            .then((response) => {
+                this.setState({hasCreatorPermission: !!response.data});
+            })
+            .catch(() => {
+                this.setState({hasCreatorPermission: false});
+            })
     }
 
     /**
@@ -150,13 +168,18 @@ export default class DashboardListingPage extends Component {
                 <div style={styles.thumbnailsWrapper}>
                     {this.renderDashboardThumbnails()}
                 </div>
-                <div style={styles.actionButton}>
-                    <span title="Create Dashboard">
-                        <FloatingActionButton onClick={() => this.props.history.push('/create')} >
-                            <ContentAdd />
-                        </FloatingActionButton>
-                    </span>
-                </div>
+                {
+                    this.state.hasCreatorPermission &&
+                    (
+                        <div style={styles.actionButton}>
+                            <span title="Create Dashboard">
+                                <FloatingActionButton onClick={() => this.props.history.push('/create')} >
+                                    <ContentAdd />
+                                </FloatingActionButton>
+                            </span>
+                        </div>
+                    )
+                }
             </MuiThemeProvider>
         );
     }

--- a/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
+++ b/components/dashboards-web-component/src/utils/apis/DashboardAPI.jsx
@@ -108,6 +108,17 @@ export default class DashboardAPI {
     }
 
     /**
+     * Check if the user has creator permissions.
+     *
+     * @param {string} username Username
+     */
+    hasCreatorPermission(username) {
+        return new DashboardAPI()
+            .getHTTPClient()
+            .get(`roles/${username}/iscreator`);
+    }
+
+    /**
      * Get roles associated for a particular dashboard.
      *
      * @param {string} dashboardId Dashboard ID

--- a/components/dashboards-web-component/src/widget-store/components/WidgetStoreCard.jsx
+++ b/components/dashboards-web-component/src/widget-store/components/WidgetStoreCard.jsx
@@ -218,7 +218,7 @@ class WidgetStoreCard extends Component {
                                     {title}
                                 </span>
                                 <div>
-                                    {config.isGenerated && (
+                                    {config.isGenerated && this.props.deletable && (
                                         <ActionDelete
                                             onClick={this.showDeleteConfirmDialog}
                                             style={Object.assign(styles.deleteIcon,
@@ -257,6 +257,7 @@ WidgetStoreCard.propTypes = {
         thumbnailURL: PropTypes.string.isRequired,
         configs: PropTypes.array.isRequired,
     }).isRequired,
+    deletable: PropTypes.bool.isRequired,
 };
 
 export default withRouter(WidgetStoreCard);

--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
@@ -235,6 +235,21 @@ public class DashboardRestApi implements Microservice {
     }
 
     @GET
+    @Path("/roles/{username}/iscreator")
+    public Response isCreator(@PathParam("username") String username) {
+        try {
+            boolean isCreator = dashboardDataProvider.isCreator(username);
+            return Response.ok()
+                    .entity(isCreator)
+                    .build();
+        } catch (DashboardException e) {
+            return Response.serverError()
+                    .entity("Cannot read user roles for '" + username + "'.")
+                    .build();
+        }
+    }
+
+    @GET
     @Path("/{url}/roles")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getDashboardRoles(@PathParam("url") String url) {

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
@@ -129,4 +129,5 @@ public interface DashboardMetadataProvider {
 
     DashboardConfigurations getReportGenerationConfigurations();
 
+    boolean isCreator(String username) throws DashboardException;
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/roles/provider/Roles.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/roles/provider/Roles.java
@@ -34,5 +34,4 @@ public class Roles {
     public List<String> getCreators() {
         return creators;
     }
-
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -455,4 +455,26 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
     public DashboardConfigurations getReportGenerationConfigurations() {
         return this.dashboardConfigurations;
     }
+
+    @Override
+    public boolean isCreator(String username) throws DashboardException {
+        List<org.wso2.carbon.analytics.idp.client.core.models.Role> userRoles;
+        boolean isCreator = false;
+        try {
+            userRoles = identityClient.getUserRoles(username);
+        } catch (IdPClientException e) {
+            throw new DashboardException("Unable to get roles for the username.");
+        }
+        RolesProvider rolesProvider = new RolesProvider(dashboardConfigurations);
+        List<String> creatorRoleIds = rolesProvider.getCreatorRoleIds();
+        for (org.wso2.carbon.analytics.idp.client.core.models.Role userRole : userRoles) {
+            for (String creatorRoleId : creatorRoleIds) {
+                if (userRole.getId().equalsIgnoreCase(creatorRoleId)) {
+                    isCreator = true;
+                    break;
+                }
+            }
+        }
+        return isCreator;
+    }
 }


### PR DESCRIPTION
## Purpose
In dashboards, even a role is not configured as a creator the user can create a dashboard and widget from the portal app. This PR fixes the issue.

Adding the following configuration in the dashboard's `deployment.yaml` file will allow only user users with role `<ROLE_ID>` to create dashboards and widgets within the portal app.

```yaml
wso2.dashboard:
  roles:
    creators:
      - <ROLE_ID>
```

Resolving https://github.com/wso2/product-sp/issues/1038

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes