### PR TITLE
Support import/export dashboard permissions

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
@@ -300,10 +300,10 @@ public class DashboardRestApi implements Microservice {
     @GET
     @Path("/{url}/export")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response exportDashboard(@PathParam("url") String url, @QueryParam("download") boolean download) {
-
+    public Response exportDashboard(@PathParam("url") String url, @QueryParam("download") boolean download,
+                                    @QueryParam("permissions") boolean permissions) {
         try {
-            DashboardArtifact artifact = dashboardDataProvider.exportDashboard(url);
+            DashboardArtifact artifact = dashboardDataProvider.exportDashboard(url, permissions);
             Response.ResponseBuilder responseBuilder = Response.ok(artifact);
             if (download) {
                 responseBuilder.header("Content-Disposition", "attachment; filename=\""

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
@@ -116,6 +116,8 @@ public interface DashboardMetadataProvider {
     void updateDashboardRoles(String user, String dashboardUrl, Map<String, List<String>> roles) throws
             DashboardException;
 
+    void updateDashboardRoles(String dashboardUrl, Map<String, List<String>> roles) throws DashboardException;
+
     /**
      * Return exportable dashboard definition.
      *
@@ -125,7 +127,7 @@ public interface DashboardMetadataProvider {
      * @return Exportable dashboard definition
      * @throws DashboardException If an error occurred while reading or processing dashboards
      */
-    DashboardArtifact exportDashboard(String dashboardUrl) throws DashboardException;
+    DashboardArtifact exportDashboard(String dashboardUrl, boolean permissions) throws DashboardException;
 
     DashboardConfigurations getReportGenerationConfigurations();
 

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/DashboardArtifact.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/importer/DashboardArtifact.java
@@ -20,6 +20,10 @@ package org.wso2.carbon.dashboards.core.bean.importer;
 
 import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Defines a dashboard data format to import/export a dashboard.
  *
@@ -28,6 +32,7 @@ import org.wso2.carbon.dashboards.core.bean.DashboardMetadata;
 public class DashboardArtifact {
     private DashboardMetadata dashboard;
     private WidgetCollection widgets = new WidgetCollection();
+    private Map<String, List<String>> permissions = new HashMap<>();
 
     /**
      * Returns dashboard metadata object.
@@ -63,5 +68,17 @@ public class DashboardArtifact {
      */
     public void setWidgets(WidgetCollection widgets) {
         this.widgets = widgets;
+    }
+
+    public Map<String, List<String>> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(Map<String, List<String>> permissions) {
+        this.permissions = permissions;
+    }
+
+    public void addPermissions(String permission, List<String> roles) {
+        permissions.put(permission, roles);
     }
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardImporter.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.utils.Utils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -44,6 +45,12 @@ import java.util.Map;
 public class DashboardImporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DashboardImporter.class);
+    public static final String PERMISSION_VIEWERS = "viewers";
+    public static final String PERMISSION_EDITORS = "editors";
+    public static final String PERMISSION_OWNERS = "owners";
+    public static final String PERMISSION_VIEWER = "viewer";
+    public static final String PERMISSION_EDITOR = "editor";
+    public static final String PERMISSION_OWNER = "owner";
 
     private final DashboardMetadataProvider dashboardMetadataProvider;
     private final WidgetMetadataProvider widgetMetadataProvider;
@@ -77,6 +84,20 @@ public class DashboardImporter {
                 } else {
                     dashboardMetadataProvider.add(dashboard);
                 }
+
+                // Fix keys before saving
+                Map<String, List<String>> permissionMap = dashboardArtifact.getPermissions();
+                if (permissionMap.containsKey(PERMISSION_VIEWERS)) {
+                    permissionMap.put(PERMISSION_VIEWER, permissionMap.remove(PERMISSION_VIEWERS));
+                }
+                if (permissionMap.containsKey(PERMISSION_EDITORS)) {
+                    permissionMap.put(PERMISSION_EDITOR, permissionMap.remove(PERMISSION_EDITORS));
+                }
+                if (permissionMap.containsKey(PERMISSION_OWNERS)) {
+                    permissionMap.put(PERMISSION_OWNER, permissionMap.remove(PERMISSION_OWNERS));
+                }
+                dashboardMetadataProvider.updateDashboardRoles(dashboard.getUrl(), dashboardArtifact.getPermissions());
+
             } catch (DashboardException e) {
                 LOGGER.warn("Cannot save dashboard importing from '{}' to the database.", dashboardArtifactPath, e);
                 continue;


### PR DESCRIPTION
## Purpose
This PR introduces support to import/export dashboard permissions while importing/exporting dashboards. 

## Approach
Following REST API allows exporting dashboards with permissions.

```
/portal/apis/dashboards/<DASHBOARD_ID>/export?permissions=true
```

**Result:**

```json
{
    "dashboard": { },
    "widgets": { },
    "permissions": {
        "viewers": ["role_1", "role_2"],
        "owners": ["role_1"],
        "editors": ["role_2"]
    }
}
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes