### PR TITLE
Fix auto complete suggestions getting cut-off

### DIFF
--- a/components/dashboards-web-component/src/designer/DashboardSettingsRoles.jsx
+++ b/components/dashboards-web-component/src/designer/DashboardSettingsRoles.jsx
@@ -196,7 +196,7 @@ export default class DashboardSettingsRoles extends Component {
     render() {
         const { muiTheme } = this.props;
         return (
-            <div>
+            <div style={{ width : '50%' }}>
                 {
                     actors.map((actor) => {
                         return (
@@ -215,6 +215,7 @@ export default class DashboardSettingsRoles extends Component {
                                         this.state.roles[actor].text = t;
                                         this.setState({ roles: this.state.roles });
                                     }}
+                                    fullWidth
                                 />
                                 <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                                     {


### PR DESCRIPTION
## Purpose
Suggestions in the dashboard settings page for different permission settings (Owner, Editor, Viewer) are getting cut off and this PR fix that issue.