### PR TITLE
Fix menu not appearing issue for users with Designer permission

### DIFF
--- a/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
+++ b/components/dashboards-web-component/src/listing/components/DashboardCard.jsx
@@ -160,7 +160,7 @@ class DashboardCard extends Component {
     }
 
     renderMenu(dashboard) {
-        if (!(dashboard.hasOwnerPermission && dashboard.hasDesignerPermission)) {
+        if (!(dashboard.hasOwnerPermission || dashboard.hasDesignerPermission)) {
             return null;
         }
 
@@ -245,7 +245,7 @@ class DashboardCard extends Component {
                             <div>
                                 <span style={styles.cardTitle}>{title}</span>
                                 {
-                                    dashboard.hasOwnerPermission && dashboard.hasDesignerPermission &&
+                                    (dashboard.hasOwnerPermission || dashboard.hasDesignerPermission) &&
                                     (<NavigationMoreVert onClick={this.handleMenuIconClick} style={styles.menuIcon} />)
                                 }
                             </div>


### PR DESCRIPTION
## Purpose
Menu which has Design, Settings, Export, Delete was not displayed for users with Dashboard Designer permission. This PR fixes that issue and display the menu with the Design and Export options for users with Dashboard Designer permission.