### PR TITLE
Clear cookies at the sso logout

### DIFF
--- a/components/dashboards-web-component/src/auth/utils/AuthManager.jsx
+++ b/components/dashboards-web-component/src/auth/utils/AuthManager.jsx
@@ -214,9 +214,12 @@ export default class AuthManager {
      * @returns {Promise<any>}
      */
     static ssoLogout() {
-        return new Promise((resolve, reject) =>{
-            AuthenticationAPI.ssoLogout(AuthManager.getUser().SDID,AuthManager.getCookie(Constants.ID_TOKEN_COOKIE))
-                .then((response) => resolve(response.data.externalLogoutUrl))
+        return new Promise((resolve, reject) => {
+            AuthenticationAPI.ssoLogout(AuthManager.getUser().SDID, AuthManager.getCookie(Constants.ID_TOKEN_COOKIE))
+                .then((response) => {
+                    AuthManager.discardSession();
+                    resolve(response.data.externalLogoutUrl);
+                })
                 .catch((error) => reject(error));
         })
     }


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/analytics-apim/issues/737

## Goals
DASHBOARD_USER cookie and other cookies are cleared from the browser at the sso logout.