### PR TITLE
Fix issue of websocket getting closed after an idle client

### DIFF
--- a/components/dashboards-web-component/src/utils/WidgetChannelManager.js
+++ b/components/dashboards-web-component/src/utils/WidgetChannelManager.js
@@ -138,7 +138,7 @@ class WidgetChannelManager {
      * @private
      */
     _wsOnClose(message) {
-        // TODO: handle on close event
+        setTimeout(this._initializeWebSocket, 1000);
     }
 
     waitForConn(socket, callback) {


### PR DESCRIPTION
## Purpose
If there is no transfer between server and client, after a certain time, the WebSocket connection is closed automatically and this results in showing circular progress in widgets. 
This PR will re-open the web socket connection when it gets closed.
Resolves https://github.com/wso2/analytics-apim/issues/844

## Goals
WebSocket client gets the ability re-open the connection in situations like temporary network problems etc.

## Approach
This fix implemented in this PR is to listen to onclose events on the web socket client and when they occur, set a client side timeout to re-open the connection.