### PR TITLE
Support to add a custom favicon

### DIFF
--- a/components/dashboards-web-component/package-lock.json
+++ b/components/dashboards-web-component/package-lock.json
@@ -3465,8 +3465,7 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -13188,6 +13187,17 @@
         "warning": "^3.0.0"
       }
     },
+    "react-helmet": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
+      "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.4",
+        "react-side-effect": "^1.1.0"
+      }
+    },
     "react-intl": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.4.0.tgz",
@@ -13269,6 +13279,14 @@
             "js-tokens": "^3.0.0"
           }
         }
+      }
+    },
+    "react-side-effect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
+      "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
+      "requires": {
+        "shallowequal": "^1.0.1"
       }
     },
     "react-simple-maps": {

--- a/components/dashboards-web-component/package.json
+++ b/components/dashboards-web-component/package.json
@@ -41,7 +41,8 @@
     "react-router-dom": "^4.1.2",
     "react-speed-dial": "^0.4.7",
     "react-tooltip": "^3.4.0",
-    "react-vizgrammar": "^0.7.14"
+    "react-vizgrammar": "^0.7.14",
+    "react-helmet": "5.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/components/dashboards-web-component/public/index.hbs
+++ b/components/dashboards-web-component/public/index.hbs
@@ -6,7 +6,8 @@
     <title>Analytics Dashboard</title>
     <link rel="stylesheet" type="text/css"
           href="{{@contextPath}}/public/app/js/libs/font-wso2_1.0.0/css/font-wso2.min.css" />
-    <link rel="shortcut icon" href="{{@contextPath}}/public/app/images/favicon.ico" type="image/x-icon" />
+    <link id="favicon" rel="shortcut icon" href="{{@contextPath}}/public/app/images/favicon.ico" type="image/x-icon"
+          data-react-helmet="true" />
 </head>
 <body>
 <div id="content"></div>

--- a/components/dashboards-web-component/src/common/Header.jsx
+++ b/components/dashboards-web-component/src/common/Header.jsx
@@ -21,68 +21,82 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import { AppBar } from 'material-ui';
+import { Helmet } from 'react-helmet';
+import Axios from 'axios';
 
 import UserMenu from './UserMenu';
 import defaultTheme from '../utils/Theme';
-import Axios from "axios";
-import AuthManager from "../auth/utils/AuthManager";
+
+import AuthManager from '../auth/utils/AuthManager';
 
 const baseURL = `${window.location.origin}${window.contextPath}/apis/dashboards`;
 const logoPathPostfix = '/logo.svg';
+const faviconPostfix = '/favicon.ico';
 
 export default class Header extends Component {
-
     constructor(props) {
         super(props);
         this.state = {
-            logoPath: ''
-        }
+            themeConfigPath: '',
+        };
     }
 
     componentDidMount() {
         Axios.create({
-            baseURL: baseURL,
+            baseURL,
             timeout: 300000,
-            headers: {"Authorization": "Bearer " + AuthManager.getUser().SDID}
+            headers: { Authorization: 'Bearer ' + AuthManager.getUser().SDID },
         })
-            .get(`/theme-config-path`)
-            .then(response => {
-                let completeLogoPath = response.data + logoPathPostfix;
-                this.setState({logoPath: completeLogoPath})
+            .get('/theme-config-path')
+            .then((response) => {
+                this.setState({ themeConfigPath: response.data });
             })
-            .catch(error => {
+            .catch((error) => {
                 console.error('Unable to get the logo path for the dashboard.', error);
             });
     }
 
     render() {
+        const { themeConfigPath } = this.state;
         const logo = (
-            <Link style={{ height: '17px' }} to={'/'}>
+            <Link style={{ height: '17px' }} to="/">
                 <img
                     height='17'
-                    src={this.state.logoPath}
+                    src={themeConfigPath + logoPathPostfix}
                     alt='logo'
                 />
             </Link>
         );
+        const {
+            onLogoClick, theme, title, rightElement,
+        } = this.props;
         return (
-            <AppBar
-                style={{ zIndex: this.props.theme.zIndex.drawer + 100 }}
-                title={this.props.title}
-                iconElementRight={this.props.rightElement}
-                iconElementLeft={logo}
-                onLeftIconButtonClick={this.props.onLogoClick}
-                iconStyleLeft={{ margin: '0 15px 0 0', display: 'flex', alignItems: 'center' }}
-                titleStyle={{ fontSize: 16 }}
-                zDepth={2}
-            />
+            <>
+                <Helmet>
+                    <link
+                        id="favicon"
+                        rel="shortcut icon"
+                        href={themeConfigPath + faviconPostfix}
+                        type="image/x-icon"
+                    />
+                </Helmet>
+                <AppBar
+                    style={{ zIndex: theme.zIndex.drawer + 100 }}
+                    title={title}
+                    iconElementRight={rightElement}
+                    iconElementLeft={logo}
+                    onLeftIconButtonClick={onLogoClick}
+                    iconStyleLeft={{ margin: '0 15px 0 0', display: 'flex', alignItems: 'center' }}
+                    titleStyle={{ fontSize: 16 }}
+                    zDepth={2}
+                />
+            </>
         );
     }
 }
 
 
 Header.propTypes = {
-    logo: PropTypes.element,
     onLogoClick: PropTypes.func,
     title: PropTypes.oneOfType([
         PropTypes.string,


### PR DESCRIPTION
## Purpose
It is required to change the favicon icon of the analytics-dashboard app when customizing the theme of the dashboard application. This PR adds that capability.

## Goals
Ability to white label dashboard application

## Approach
A react library called react-helmet is used. And the default path to the favicon icon is retrieved from the DefaultDashboardThemeConfigProvider class and if its needed to be changed a config needs to be added to the deployment.yaml of the respective product.

Example:
In APIM Analytics deployment.yaml file of dashboard profile we have to add the below config. This CustomDashboardThemeConfigProvider will read the themeConfigResourcesPath from config and append tenant domain to its path at the end.

 `
themeConfigProviderClass: org.wso2.analytics.apim.dashboards.theme.config.provider.CustomDashboardThemeConfigProvider
`
`
  themeConfigResourcesPath: https://localhost:9643/analytics-dashboard/public/app/images
`

And in the above case the custom images needs to be saved at a HOME/wso2/dashboard/deployment/web-ui-apps/analytics-dashboard/public/images/{tenant_deirectory}