### PR TITLE
Fix tenant wise themeing paths

### DIFF
--- a/components/dashboards-web-component/src/common/Header.jsx
+++ b/components/dashboards-web-component/src/common/Header.jsx
@@ -30,39 +30,47 @@ import defaultTheme from '../utils/Theme';
 import AuthManager from '../auth/utils/AuthManager';
 
 const baseURL = `${window.location.origin}${window.contextPath}/apis/dashboards`;
-const logoPathPostfix = '/logo.svg';
-const faviconPostfix = '/favicon.ico';
 
 export default class Header extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            themeConfigPath: '',
+            faviconPath: '',
+            logoPath: '',
         };
     }
 
     componentDidMount() {
-        Axios.create({
+        const httpClient = Axios.create({
             baseURL,
             timeout: 300000,
             headers: { Authorization: 'Bearer ' + AuthManager.getUser().SDID },
-        })
-            .get('/theme-config-path')
+        });
+
+        httpClient.get('/favicon-path')
             .then((response) => {
-                this.setState({ themeConfigPath: response.data });
+                this.setState({ faviconPath: response.data });
             })
             .catch((error) => {
-                console.error('Unable to get the logo path for the dashboard.', error);
+                console.error('Unable to get the favicon path for the dashboard.', error);
+            });
+
+        httpClient.get('/logo-path')
+            .then((response) => {
+                this.setState({ logoPath: response.data });
+            })
+            .catch((error) => {
+                console.error('Unable to get the logo image path for the dashboard.', error);
             });
     }
 
     render() {
-        const { themeConfigPath } = this.state;
+        const { faviconPath, logoPath } = this.state;
         const logo = (
             <Link style={{ height: '17px' }} to="/">
                 <img
                     height='17'
-                    src={themeConfigPath + logoPathPostfix}
+                    src={logoPath}
                     alt='logo'
                 />
             </Link>
@@ -76,7 +84,7 @@ export default class Header extends Component {
                     <link
                         id="favicon"
                         rel="shortcut icon"
-                        href={themeConfigPath + faviconPostfix}
+                        href={faviconPath}
                         type="image/x-icon"
                     />
                 </Helmet>

--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
@@ -360,7 +360,7 @@ public class DashboardRestApi implements Microservice {
     /**
      * Gets path where fav icon is stored.
      *
-     * @since 4.1.14
+     * @since 4.1.16
      *
      * @return response
      */
@@ -380,7 +380,7 @@ public class DashboardRestApi implements Microservice {
     /**
      * Gets path where fav icon is stored.
      *
-     * @since 4.1.14
+     * @since 4.1.16
      *
      * @return response
      */

--- a/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.api/src/main/java/org/wso2/carbon/dashboards/api/internal/DashboardRestApi.java
@@ -358,21 +358,41 @@ public class DashboardRestApi implements Microservice {
     }
 
     /**
-     * Gets parent path where logo, fav icon etc. are stored.
+     * Gets path where fav icon is stored.
      *
      * @since 4.1.14
      *
      * @return response
      */
     @GET
-    @Path("/theme-config-path")
-    public Response getThemeConfigPath(@Context Request request) {
+    @Path("/favicon-path")
+    public Response getFaviconPath(@Context Request request) {
+        String faviconPath;
+        try {
+            faviconPath = dashboardDataProvider.getFaviconPath(getUserName(request));
+        } catch (DashboardException e) {
+            LOGGER.error("Cannot get the path where favicon is stored.", e);
+            return Response.serverError().entity("Cannot get the path where favicon is stored.").build();
+        }
+        return Response.ok().entity(faviconPath).build();
+    }
+
+    /**
+     * Gets path where fav icon is stored.
+     *
+     * @since 4.1.14
+     *
+     * @return response
+     */
+    @GET
+    @Path("/logo-path")
+    public Response getLogoPath(@Context Request request) {
         String logoPath;
         try {
-            logoPath = dashboardDataProvider.getThemeConfigPath(getUserName(request));
+            logoPath = dashboardDataProvider.getLogoPath(getUserName(request));
         } catch (DashboardException e) {
-            LOGGER.error("Cannot get the path where theme resources are stored.", e);
-            return Response.serverError().entity("Cannot get the path where theme resources are stored.").build();
+            LOGGER.error("Cannot get the path where logo image is stored.", e);
+            return Response.serverError().entity("Cannot get the path where logo image is stored.").build();
         }
         return Response.ok().entity(logoPath).build();
     }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
@@ -138,13 +138,24 @@ public interface DashboardMetadataProvider {
     boolean isWidgetCreator(String username) throws DashboardException;
 
     /**
-     * Return the path where fav icon, logo etc. are stored.
+     * Return the path where fav icon is stored.
      *
      * @since 4.1.14
      *
      * @param username name of the user
-     * @return Return theme content stored path
-     * @throws DashboardException If an error occurred while getting the theme content stored path
+     * @return Return path of the favicon icon
+     * @throws DashboardException If an error occurred while getting the favicon path
      */
-    String getThemeConfigPath(String username) throws DashboardException;
+    String getFaviconPath(String username) throws DashboardException;
+
+    /**
+     * Return the path where logo image is stored.
+     *
+     * @since 4.1.14
+     *
+     * @param username name of the user
+     * @return Return path of the logo image
+     * @throws DashboardException If an error occurred while getting the favicon path
+     */
+    String getLogoPath(String username) throws DashboardException;
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardMetadataProvider.java
@@ -140,7 +140,7 @@ public interface DashboardMetadataProvider {
     /**
      * Return the path where fav icon is stored.
      *
-     * @since 4.1.14
+     * @since 4.1.16
      *
      * @param username name of the user
      * @return Return path of the favicon icon
@@ -151,7 +151,7 @@ public interface DashboardMetadataProvider {
     /**
      * Return the path where logo image is stored.
      *
-     * @since 4.1.14
+     * @since 4.1.16
      *
      * @param username name of the user
      * @return Return path of the logo image

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardThemeConfigProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DashboardThemeConfigProvider.java
@@ -26,11 +26,21 @@ import org.wso2.carbon.dashboards.core.exception.DashboardException;
 public interface DashboardThemeConfigProvider {
 
     /**
-     * Return the path where fav icon, logo etc. are stored.
+     * Return the path where fav icon is stored.
      *
      * @param username full username(ex: admin@carbon.super).
-     * @return path where theme resources(fav icon, logo etc) are stored.
-     * @throws DashboardException if getting path where dashboard resources are stored, failed due to exception.
+     * @return path to the favicn icon
+     * @throws DashboardException if getting path where favicon is stored, failed due to exception.
      */
-    String getPath(String username) throws DashboardException;
+    String getFaviconPath(String username) throws DashboardException;
+
+    /**
+     * Return the path where logo image is stored.
+     *
+     * @param username full username(ex: admin@carbon.super).
+     * @return path to the logo image
+     * @throws DashboardException if getting path where logo image is stored, failed due to exception.
+     */
+    String getLogoPath(String username) throws DashboardException;
+
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DefaultDashboardThemeConfigProvider.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/DefaultDashboardThemeConfigProvider.java
@@ -63,13 +63,25 @@ public class DefaultDashboardThemeConfigProvider implements DashboardThemeConfig
     }
 
     @Override
-    public String getPath(String username) throws DashboardException {
+    public String getFaviconPath(String username) throws DashboardException {
         Map<String, String> properties = idPClientConfiguration.getProperties();
         String baseUrl = properties.getOrDefault(ExternalIdPClientConstants.BASE_URL,
                 ExternalIdPClientConstants.DEFAULT_BASE_URL);
         String portalAppContext = properties.getOrDefault(ExternalIdPClientConstants.PORTAL_APP_CONTEXT,
                 ExternalIdPClientConstants.DEFAULT_PORTAL_APP_CONTEXT);
-        String logoPath = baseUrl + "/" + portalAppContext + "/public/app/images";
+        String faviconPath = baseUrl + "/" + portalAppContext + "/public/app/images/favicon.ico";
+        LOGGER.debug("Default path returned via '{}' class for user: '{}.'", this.getClass().getName(), username);
+        return faviconPath;
+    }
+
+    @Override
+    public String getLogoPath(String username) throws DashboardException {
+        Map<String, String> properties = idPClientConfiguration.getProperties();
+        String baseUrl = properties.getOrDefault(ExternalIdPClientConstants.BASE_URL,
+                ExternalIdPClientConstants.DEFAULT_BASE_URL);
+        String portalAppContext = properties.getOrDefault(ExternalIdPClientConstants.PORTAL_APP_CONTEXT,
+                ExternalIdPClientConstants.DEFAULT_PORTAL_APP_CONTEXT);
+        String logoPath = baseUrl + "/" + portalAppContext + "/public/app/images/logo.svg";
         LOGGER.debug("Default path returned via '{}' class for user: '{}.'", this.getClass().getName(), username);
         return logoPath;
     }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardConfigurations.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardConfigurations.java
@@ -57,7 +57,6 @@ public class DashboardConfigurations {
     @Element(description = "file name of the favicon")
     public String faviconFileName = "favicon.ico";
 
-
     /**
      * Get map of roles.
      *

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardConfigurations.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/bean/DashboardConfigurations.java
@@ -51,6 +51,13 @@ public class DashboardConfigurations {
     @Element(description = "Location where theme configuration resources(ex: fav icon, logo etc.) are stored in")
     public String themeConfigResourcesPath = "https://localhost:9643/analytics-dashboard/public/app/images";
 
+    @Element(description = "file name of the logo image")
+    public String logoFileName = "logo.svg";
+
+    @Element(description = "file name of the favicon")
+    public String faviconFileName = "favicon.ico";
+
+
     /**
      * Get map of roles.
      *
@@ -95,5 +102,24 @@ public class DashboardConfigurations {
     public String getThemeConfigResourcesPath() {
         return themeConfigResourcesPath;
     }
+
+    /**
+     * Get file name of the logo image.
+     *
+     * @return logo image file name
+     */
+    public String getLogoFileName() {
+        return logoFileName;
+    }
+
+    /**
+     * Get file name of the favicon.
+     *
+     * @return favicon icon file name
+     */
+    public String getFaviconFileName() {
+        return faviconFileName;
+    }
+
 
 }

--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -502,7 +502,12 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
     }
 
     @Override
-    public String getThemeConfigPath(String username) throws DashboardException {
-        return this.dashboardThemeConfigProvider.getPath(username);
+    public String getFaviconPath(String username) throws DashboardException {
+        return this.dashboardThemeConfigProvider.getFaviconPath(username);
+    }
+
+    @Override
+    public String getLogoPath(String username) throws DashboardException {
+        return this.dashboardThemeConfigProvider.getLogoPath(username);
     }
 }


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/analytics-apim/issues/1007

## Goals
To provide the ability to upload a single themeing zip from admin portal of APIM and reuse the same for Analytics as well.

## Approach
This PR removes the api method "/theme-config-path" and add two api methods namely /favicon-path" and "/logo-path" and their impls

So if a user wants to change the current logo and favicon he needs to add a configuration similar to below in the deployment.yaml file.

`themeConfigProviderClass: org.wso2.analytics.apim.dashboards.theme.config.provider.CustomDashboardThemeConfigProvider`
 ` themeConfigResourcesPath: public/app`
  `logoFileName: download.png`
  `faviconFileName: favicon.ico`