### PR TITLE
Fixed owner when adding dashboard

### DIFF
--- a/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
+++ b/components/dashboards/org.wso2.carbon.dashboards.core/src/main/java/org/wso2/carbon/dashboards/core/internal/DashboardMetadataProviderImpl.java
@@ -220,6 +220,7 @@ public class DashboardMetadataProviderImpl implements DashboardMetadataProvider 
                 .filter(role -> hasRoles(user, role))
                 .collect(Collectors.toSet());
         if (!filteredRoleIds.isEmpty()) {
+            dashboardMetadata.setOwner(user);
             dao.add(dashboardMetadata);
             for (Permission permission : buildDashboardPermissions(dashboardMetadata.getUrl())) {
                 permissionProvider.addPermission(permission);


### PR DESCRIPTION
## Purpose
Wehn duplicate dashboard it's the owner should be currently logged in user. Also when adding a new dashboard, the owner should be the same way.