### PR TITLE
Increase widget loader timeout

### DIFF
--- a/components/dashboards-web-component/src/common/WidgetRenderer.jsx
+++ b/components/dashboards-web-component/src/common/WidgetRenderer.jsx
@@ -101,7 +101,7 @@ export default class WidgetRenderer extends Component {
         this.updateWidgetLoadingStatus(WidgetLoadingStatus.FETCHING);
         Axios.create({
             baseURL: widgetScriptUrlPrefix,
-            timeout: 10000,
+            timeout: 60000,
             onDownloadProgress: (progressEvent) => {
                 let progress = progressEvent.lengthComputable ?
                     ((progressEvent.loaded / progressEvent.total) * 100) : -1;


### PR DESCRIPTION
## Purpose
This PR increases the timeout value for widget loader from 10000ms to 60000ms.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes