### PR TITLE
Increase Analytics Dashboard Widget Timeout

### DIFF
--- a/base-widget/src/Widget.jsx
+++ b/base-widget/src/Widget.jsx
@@ -186,7 +186,7 @@ export default class Widget extends Component {
     getWidgetConfiguration(widgetId) {
         let httpClient = Axios.create({
             baseURL: window.location.origin + window.contextPath,
-            timeout: 2000,
+            timeout: 60000,
             headers: {"Authorization": "Bearer " + JSON.parse(Widget._getSessionCookie(SESSION_USER)).SDID},
         });
         httpClient.defaults.headers.post['Content-Type'] = 'application/json';


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/analytics-apim/issues/1413

## Goals
This PR increases the Analytics Dashboard Widget Timeout from 2000 to 60000.
