### PR TITLE
Bump @wso2-dashboards/widget version to 1.5.1

### DIFF
--- a/base-widget/package.json
+++ b/base-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wso2-dashboards/widget",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "This is the base(parent) widget for dashboard component. Users can extend this react component and write their own widgets",
   "main": "lib/Widget.js",
   "repository": {

--- a/base-widget/src/Widget.jsx
+++ b/base-widget/src/Widget.jsx
@@ -194,4 +194,4 @@ export default class Widget extends Component {
     }
 }
 
-Widget.version = '1.4.0';
+Widget.version = '1.5.1';


### PR DESCRIPTION
## Purpose
Aims to fix https://github.com/wso2/analytics-apim/issues/1413

## Goals
This PR bumps version of @wso2-dashboards/widget from 1.5.0 to 1.5.1 in order to publish node module with changes to registry.