### PR TITLE
Fix continuous unauthorized log issue in dashboards

### DIFF
--- a/components/dashboards-web-component/src/auth/SecuredRouter.jsx
+++ b/components/dashboards-web-component/src/auth/SecuredRouter.jsx
@@ -64,7 +64,7 @@ export default class SecuredRouter extends Component {
                         console.debug('Token refresh successful.');
                     }).catch(() => {
                         console.log('Token refresh failed.');
-                        history.push('/login');
+                        location.reload();
                     });
                 }
             } else {


### PR DESCRIPTION
## Purpose
This PR fixes an issue where unauthorized logs were printing continuously when websocket connection closes while the user is viewing a dashboard.

Related issue: https://github.com/wso2/analytics-apim/issues/1515